### PR TITLE
Primer design UI update: modifying json parameters

### DIFF
--- a/public/js/p3/widget/app/PrimerDesign.js
+++ b/public/js/p3/widget/app/PrimerDesign.js
@@ -127,8 +127,8 @@ define([
             }
         }
         //output
-        json_payload["output_path".toUpperCase()] = curr_vars["output_path"];
-        json_payload["output_file".toUpperCase()] = curr_vars["output_file"];
+        json_payload["output_path"] = curr_vars["output_path"];
+        json_payload["output_file"] = curr_vars["output_file"];
         return json_payload;
     },
 


### PR DESCRIPTION
Submitting json with OUTPUT_PATH and OUTPUT_FILE caused the job submission to not recognize the output folder. Switched them to lowercase, output_path and output_file, fixes this issue.