### PR TITLE
Fixed bug in Assembly2.js

### DIFF
--- a/public/js/p3/widget/app/Assembly2.js
+++ b/public/js/p3/widget/app/Assembly2.js
@@ -493,7 +493,7 @@ define([
       assembly_values.recipe = values.recipe;
       //output_path and output_file
       assembly_values.output_path = values.output_path;
-      this.output_path = values.output_path;
+      this.output_folder = values.output_path;
       assembly_values.output_file = values.output_file;
       this.output_name = values.output_file;
 


### PR DESCRIPTION
Named an attribute wrong which conflicted with the required output_path attribute. Changed my attribute to the appropriate name 