### PR TITLE
Fix for duplicated library entries 

### DIFF
--- a/public/js/p3/widget/app/AppBase.js
+++ b/public/js/p3/widget/app/AppBase.js
@@ -475,10 +475,6 @@ define([
       }
     },
 
-    /*
-    //FUNCTIONS BELOW RELATED TO FORM FILLING
-    */
-
     // Assumes the localStorage ID is "bvbrc_rerun_job"
     // Note: delete "bvbrc_rerun_job" key in function defined in each service (intakeRerunForm)
     // Note: omit "output_name" since the user should fill this out every time
@@ -564,6 +560,7 @@ define([
         this.addLibraryRowFormFill(lrec, infoLabels, 'singledata');
       }));
       // load SRA names: can be in eithers srr_ids (list of ids) or sra_libs (list of key-item entries)
+      // TODO: change this to one list
       if (local_job.srr_ids) {
         local_job.srr_ids.forEach(lang.hitch(this, function (srr_id) {
           var lrec = { _type: 'srr_accession', type: 'srr_accession', title: srr_id };
@@ -654,6 +651,7 @@ define([
       var handle = on(td2, 'click', lang.hitch(this, function (evt) {
         this.destroyLibRow(lrec._id, '_id');
       }));
+      // TODO: standardize this across services 
       lrec._handle = handle;
       lrec.handle = handle;
       this.libraryStore.put(lrec);

--- a/public/js/p3/widget/app/FastqUtil.js
+++ b/public/js/p3/widget/app/FastqUtil.js
@@ -734,6 +734,11 @@ define([
       assembly_values.reference_genome_id = values.genome_name;
       this.target_genome_id = assembly_values.reference_genome_id;
 
+      // empty paired, single, and sra libs
+      this.paired_end_libs = [];
+      this.single_end_libs = [];
+      this.sra_libs = [];
+
       return assembly_values;
     },
 

--- a/public/js/p3/widget/app/Rnaseq.js
+++ b/public/js/p3/widget/app/Rnaseq.js
@@ -263,6 +263,7 @@ define([
       var values = this.inherited(arguments);
 
       assembly_values = this.checkBaseParameters(values, assembly_values);
+
       if (!this.form_flag) {
         this.ingestAttachPoints(this.paramToAttachPt, assembly_values);
       }
@@ -274,6 +275,11 @@ define([
       if (Boolean(this.genome_nameWidget.item.host) && 'ftp' in this.genome_nameWidget.item) {
         assembly_values['host_ftp'] = this.genome_nameWidget.item['ftp'];
       }
+      /*
+      if (this.localStorage.hasOwnProperty('bvbrc_rerun_job')) {
+        this.localStorage.removeItem('bvbrc_rerun_job');
+      }
+      */
       return assembly_values;
     },
 
@@ -849,7 +855,7 @@ define([
       var srrList = this.libraryStore.query({ type: 'srr_accession' });
       var condLibs = [];
       var contrastPairs = [];
-
+      console.log('assembly_values = ', assembly_values);
       var combinedList = pairedList.concat(singleList).concat(srrList);
       if (this.exp_design.checked) {
         condList.forEach(function (condRecord) {
@@ -928,6 +934,12 @@ define([
       // output_file
       assembly_values.output_file = values.output_file;
       this.output_name = values.output_file;
+
+      // TODO: HERE, checking this works
+      // empty paired, single, and sra libs
+      this.paired_end_libs = [];
+      this.single_end_libs = [];
+      this.sra_libs = [];
 
       return assembly_values;
     },

--- a/public/js/p3/widget/app/Rnaseq.js
+++ b/public/js/p3/widget/app/Rnaseq.js
@@ -935,7 +935,6 @@ define([
       assembly_values.output_file = values.output_file;
       this.output_name = values.output_file;
 
-      // TODO: HERE, checking this works
       // empty paired, single, and sra libs
       this.paired_end_libs = [];
       this.single_end_libs = [];

--- a/public/js/p3/widget/app/Rnaseq.js
+++ b/public/js/p3/widget/app/Rnaseq.js
@@ -275,11 +275,7 @@ define([
       if (Boolean(this.genome_nameWidget.item.host) && 'ftp' in this.genome_nameWidget.item) {
         assembly_values['host_ftp'] = this.genome_nameWidget.item['ftp'];
       }
-      /*
-      if (this.localStorage.hasOwnProperty('bvbrc_rerun_job')) {
-        this.localStorage.removeItem('bvbrc_rerun_job');
-      }
-      */
+
       return assembly_values;
     },
 

--- a/public/js/p3/widget/app/Variation.js
+++ b/public/js/p3/widget/app/Variation.js
@@ -488,6 +488,12 @@ define([
       if (this.sra_libs.length) {
         submit_values.srr_ids = this.sra_libs;
       }
+
+      // empty paired, single, and sra libs
+      this.paired_end_libs = [];
+      this.single_end_libs = [];
+      this.sra_libs = [];
+
       return submit_values;
     },
 


### PR DESCRIPTION
when a user submits multiple jobs without reloading the page or equivalent the library would contain duplicate entries. Fix resets these libraries on submission