### PR TITLE
Enabled Archaeopteryx tree to order sister-clades and turn on internal labels prior to tree display

### DIFF
--- a/public/js/archaeopteryx/archaeopteryx-dependencies/archaeopteryx.js
+++ b/public/js/archaeopteryx/archaeopteryx-dependencies/archaeopteryx.js
@@ -1,7 +1,7 @@
 /**
- *  Copyright (C) 2021 Christian M. Zmasek
- *  Copyright (C) 2021 Yun Zhang
- *  Copyright (C) 2021 J. Craig Venter Institute
+ *  Copyright (C) 2022 Christian M. Zmasek
+ *  Copyright (C) 2022 Yun Zhang
+ *  Copyright (C) 2022 J. Craig Venter Institute
  *  All rights reserved
  *
  *  This library is free software; you can redistribute it and/or
@@ -21,8 +21,8 @@
  *
  */
 
-// v 2.0.0a3
-// 2022-02-25
+// v 2.0.0a4
+// 2022-03-15
 //
 // Archaeopteryx.js is a software tool for the visualization and
 // analysis of highly annotated phylogenetic trees.
@@ -73,7 +73,7 @@ if (!phyloXml) {
 
     "use strict";
 
-    const VERSION = '2.0.0a3';
+    const VERSION = '2.0.0a4';
     const WEBSITE = 'https://sites.google.com/view/archaeopteryxjs';
     const NAME = 'Archaeopteryx.js';
 
@@ -3795,7 +3795,9 @@ if (!phyloXml) {
         if (_settings.allowManualNodeSelection === undefined) {
             _settings.allowManualNodeSelection = false;
         }
-
+        if (_settings.orderTree === undefined) {
+            _settings.orderTree = false;
+        }
 
         _settings.controlsFontSize = parseInt(_settings.controlsFontSize);
 
@@ -4167,6 +4169,10 @@ if (!phyloXml) {
 
         _svgGroup = _baseSvg.append('g');
 
+
+        if (_settings.orderTree) {
+            orderSubtree(_root, true);
+        }
         if (_options.searchAinitialValue) {
             search0();
         }

--- a/public/js/bundle/bundle2.js
+++ b/public/js/bundle/bundle2.js
@@ -24227,9 +24227,9 @@ function BlurStack()
         this.forester = forester;
 })();
     /**
- *  Copyright (C) 2021 Christian M. Zmasek
- *  Copyright (C) 2021 Yun Zhang
- *  Copyright (C) 2021 J. Craig Venter Institute
+ *  Copyright (C) 2022 Christian M. Zmasek
+ *  Copyright (C) 2022 Yun Zhang
+ *  Copyright (C) 2022 J. Craig Venter Institute
  *  All rights reserved
  *
  *  This library is free software; you can redistribute it and/or
@@ -24249,8 +24249,8 @@ function BlurStack()
  *
  */
 
-// v 2.0.0a3
-// 2022-02-25
+// v 2.0.0a4
+// 2022-03-15
 //
 // Archaeopteryx.js is a software tool for the visualization and
 // analysis of highly annotated phylogenetic trees.
@@ -24301,7 +24301,7 @@ if (!phyloXml) {
 
     "use strict";
 
-    const VERSION = '2.0.0a3';
+    const VERSION = '2.0.0a4';
     const WEBSITE = 'https://sites.google.com/view/archaeopteryxjs';
     const NAME = 'Archaeopteryx.js';
 
@@ -28023,7 +28023,9 @@ if (!phyloXml) {
         if (_settings.allowManualNodeSelection === undefined) {
             _settings.allowManualNodeSelection = false;
         }
-
+        if (_settings.orderTree === undefined) {
+            _settings.orderTree = false;
+        }
 
         _settings.controlsFontSize = parseInt(_settings.controlsFontSize);
 
@@ -28395,6 +28397,10 @@ if (!phyloXml) {
 
         _svgGroup = _baseSvg.append('g');
 
+
+        if (_settings.orderTree) {
+            orderSubtree(_root, true);
+        }
         if (_options.searchAinitialValue) {
             search0();
         }

--- a/public/js/p3/widget/Phylogeny2.js
+++ b/public/js/p3/widget/Phylogeny2.js
@@ -149,8 +149,8 @@ define([
       }));
 
       this.selection = cur;
-      this.selectionActionBar.set('selection', this.selection);
       this.selectionActionBar.set('currentContainerType', this.containerType);
+      this.selectionActionBar.set('selection', this.selection);
 
       console.log('onNodeSelection before query this.nodeType', this.nodeType);
       console.log('onNodeSelection this.nodeSelection', this.nodeSelection);
@@ -309,7 +309,7 @@ define([
       options.showDisributions = true;
       options.showExternalLabels = true;
       options.showExternalNodes = false;
-      options.showInternalLabels = false;
+      options.showInternalLabels = true;
       options.showInternalNodes = false;
       options.showNodeEvents = true;
       options.showNodeName = true;
@@ -342,7 +342,8 @@ define([
       settings.nhExportWriteConfidences = true;
       settings.rootOffset = 180;
       settings.allowManualNodeSelection = true;
-
+      settings.orderTree = true;
+      
       var nodeVisualizations = {};
       var specialVisualizations = {};
       var nodeLabels = {};


### PR DESCRIPTION
This change requires Archaeopteryx submodule update to v 2.0.0a4 (2022-03-15) version and bundle2.js rebuild.