### PR TITLE
Reset the memory stores for libraries and conditions.

### DIFF
--- a/public/js/p3/widget/app/FastqUtil.js
+++ b/public/js/p3/widget/app/FastqUtil.js
@@ -385,6 +385,15 @@ define([
       domClass.remove(this.domNode, 'Working');
       domClass.remove(this.domNode, 'Error');
       domClass.remove(this.domNode, 'Submitted');
+      var condRows = this.condTable.rows.length;
+      this.activeConditionStore = new Memory({ data: [] });
+      for (var i = 0; i < condRows; i++) {
+        this.condTable.deleteRow(0);
+      }
+      this.emptyTable(this.condTable, this.initConditions, 3);
+      this.addedCond = { counter: 0 };
+      this.numAlign = 0;
+      this.toggleGenome();
       var toDestroy = [];
       this.libraryStore.data.forEach(lang.hitch(this, function (lrec) {
         toDestroy.push(lrec.id);
@@ -393,6 +402,7 @@ define([
       toDestroy.forEach(lang.hitch(this, function (id) {
         this.destroyLib({}, id, 'id');
       }));
+      this.libraryStore = new Memory({ data: [], idProperty: 'id' });
     },
 
     makeConditionName: function (conditionName) {


### PR DESCRIPTION
This fixes the reset button for fastq-utils. Libraries and pipelines weren't being cleared.

This fixes https://github.com/BV-BRC/issues/issues/672.
It is related to https://github.com/BV-BRC/issues/issues/347.