### PR TITLE
Add support for genome and feature groups in compare regions.

### DIFF
--- a/public/js/p3/widget/SEEDClient.js
+++ b/public/js/p3/widget/SEEDClient.js
@@ -33,6 +33,13 @@ define([
       );
     },
 
+    compare_regions_for_peg2: function (peg, width, n_genomes, coloring_method, genome_filter, options, _callback, _errorCallback) {
+      return this.json_call_ajax(
+        'SEED.compare_regions_for_peg2',
+        [peg, width, n_genomes, coloring_method, genome_filter, options], 1, _callback, _errorCallback
+      );
+    },
+
     get_ncbi_cdd_url: function (feature, _callback, _errorCallback) {
       return this.json_call_ajax(
         'SEED.get_ncbi_cdd_url',


### PR DESCRIPTION
This is the initial support to enable two features in compare regions:

1. Limit the scope of the comparison to the genomes in a selected genome group. 
2. Limit the scope of the comparison to the genomes corresponding to a selected feature group, and force the pin of the comparison to be the features in the group. This may be nonsensical if the features are not related to each other, but is very useful when looking at e.g. members of a protein family.

There are some cosmetic problems with this implementation that I've not been able to work out.

* The genome and feature group browser widgets force a new line in their container, making the labels not work properly and making the header take up a lot of room
* When you doubleclick to move to a new peg in the compare regions, it doesn't seem to reliably return to the state (e.g. genome group selection). We see this in the existing browser as well; when you change the region size and number of genomes and update, the display is correct. If you doubleclick on a peg the widgets show the updated values but the display is incorrect. I think the likely culprit is this: https://github.com/BV-BRC/bvbrc_website/blob/master/public/js/p3/widget/CompareRegionContainer.js#L63
* When the object selector is disabled, you can still click on the greyed out folder icon to get a browser window to appear.