### PR TITLE
fixing PageGrid.js passing primaryKey as token

### DIFF
--- a/public/js/p3/widget/IDMappingGrid.js
+++ b/public/js/p3/widget/IDMappingGrid.js
@@ -109,6 +109,10 @@ define([
         });
       });
 
+      if (!this.store && this.dataModel) {
+        this.store = this.createStore(this.dataModel);
+      }
+
       this.inherited(arguments);
       this._started = true;
     },

--- a/public/js/p3/widget/app/MetagenomicBinning.js
+++ b/public/js/p3/widget/app/MetagenomicBinning.js
@@ -236,7 +236,7 @@ define([
     // counter is a widget for requirements checking
     increaseRows: function (targetTable, counter, counterWidget) {
       counter.counter += 1;
-      if (this.libraryStore.data.length == 1 && this.libraryStore.data[0]._type == 'paired') {
+      if (this.libraryStore.data.length == 1 && (this.libraryStore.data[0]._type == 'paired' || this.libraryStore.data[0]._type == 'srr_accession')) {
         this.metaspades.set('disabled', false);
         this.metaspades.set('checked', true);
       }


### PR DESCRIPTION
For some reason PageGrid.js is calling createStore() in widget/IDMappingGrid.js by passing the primaryKey (sorting) as the auth token <through inheritance>.
Fixes https://github.com/BV-BRC/issues/issues/752