### PR TITLE
Update for compare regions 

### DIFF
--- a/public/js/p3/widget/CompareRegionContainer.js
+++ b/public/js/p3/widget/CompareRegionContainer.js
@@ -43,46 +43,104 @@ define([
     },
 
     onSetState: function (attr, oldVal, state) {
-      if (!state) {
+      console.log("onSetState", attr, oldVal, state);
+      if (!state)
+      {
         return;
       }
 
-      if (!state.feature) {
-        return;
+      if (state.feature && state.feature.patric_id)
+      {
+	if (this.patric_id == state.feature.patric_id) {
+	  return;
+	}
+	this.patric_id = state.feature.patric_id;
       }
 
-      if (this.patric_id == state.feature.patric_id) {
-        return;
-      }
-      this.patric_id = state.feature.patric_id;
-
+      /*
+       * Determine our view mode. If we have a state.feature we are viewing
+       * a single feature. (We should also see widgetClass == p3/widget/viewerFeature)
+       *
+       * Otherwise we need to look at 
+       */
 
       if (this.viewer) {
-        // this.viewer.set('state', state);
-        if (state.feature.feature_type === 'CDS') {
-          this.render(state.feature.patric_id, 10000, 10, 'pgfam', 'representative+reference');
-        } else {
-          new Dialog({
-            title: '',
-            content: 'Compare Region Viewer is only available for CDS features.',
-            style: 'width: 400px'
-          }).show();
-        }
-      }
 
-      this._set('state', state);
-    },
+	switch (state.widgetClass) {
+	  
+	  case 'p3/widget/viewer/FeatureGroup':
+	  {
+            var window = this.region_size.get('value');
+            var n_genomes = this.n_genomes.get('value');
+            var method = this.method.get('value');
+            var filter = 'feature_query';
+	    
+            this.render('', window, n_genomes, method, filter, state.search);
+	  }
 
-    render: function (peg, window, n_genomes, method, filter) {
+	  break;
+	  
+	  case 'p3/widget/viewer/FeatureList':
+	  {
+            var window = this.region_size.get('value');
+            var n_genomes = this.n_genomes.get('value');
+            var method = this.method.get('value');
+            var filter = 'feature_query';
+	    
+            this.render('', window, n_genomes, method, filter, state.search);
+	  }
+
+	  break;
+
+	  case 'p3/widget/viewer/Feature':
+	  {
+	    if (!state.feature)
+	    {
+	      console.log("Skipping due to missing feature");
+	      return;
+	    }
+	    if (state.feature.feature_type === 'CDS')
+	    {
+              var window = this.region_size.get('value');
+              var n_genomes = this.n_genomes.get('value');
+              var method = this.method.get('value');
+              var filter = this.g_filter.get('value');
+	      
+	      console.log("initial render", state.feature.patric_id, window, n_genomes, method, filter);
+              this.render(state.feature.patric_id, window, n_genomes, method, filter);
+              // this.render(state.feature.patric_id, 10000, 10, 'pgfam', 'representative+reference');
+            }
+	    else
+	    {
+              new Dialog({
+		title: '',
+		content: 'Compare Region Viewer is only available for CDS features.',
+		style: 'width: 400px'
+              }).show();
+            }
+	  }
+	  break;
+	  }
+	}
+
+	this._set('state', state);
+      },
+
+    render: function (peg, window, n_genomes, method, filter, val) {
       this.loadingMask.show();
+      console.log("RENDER:", peg, method, filter, val);
       var options = {};
       if (filter == 'genome_group') {
-	  options.genome_group = this.genome_group_selector.get('value');
+	options.genome_group = this.genome_group_selector.get('value');
       } else if (filter == 'feature_group') {
-	  options.feature_group = this.feature_group_selector.get('value');
+	options.feature_group = this.feature_group_selector.get('value');
       }
-	console.log(options);
-
+      else if (filter == 'feature_query') {
+	options.feature_query = val;
+      }
+      
+      console.log(options);
+      
       this.service.compare_regions_for_peg2(
         peg, window, n_genomes, method, filter, options,
         function (data) {
@@ -179,7 +237,7 @@ define([
       var label_region_size = domConstruct.create('label', { innerHTML: 'Region Size: ' });
       this.region_size = new Select({
         name: 'region_size',
-        value: 10000,
+        value: 5000,
         style: 'width: 100px; margin-right: 10px',
         options: [{
           value: 5000, label: '5,000bp'
@@ -300,7 +358,14 @@ console.log("enable feature ", this.feature_group_selector);
           var method = this.method.get('value');
           var filter = this.g_filter.get('value');
 
-          this.render(this.patric_id, window, n_genomes, method, filter);
+	  //
+	  // Use the state-change mechanism to implement the update since that
+	  // is where we have the logic to determine the correct render() parameters
+	  // based on in which page the compare region is embedded.
+	  //
+	  this._set('state', structuredClone(this.state));
+	  
+          // this.render(this.patric_id, window, n_genomes, method, filter);
         })
       });
       domConstruct.place(btn_submit.domNode, filterPanel.containerNode, 'last');

--- a/public/js/p3/widget/CompareRegionContainer.js
+++ b/public/js/p3/widget/CompareRegionContainer.js
@@ -237,7 +237,7 @@ define([
       var label_region_size = domConstruct.create('label', { innerHTML: 'Region Size: ' });
       this.region_size = new Select({
         name: 'region_size',
-        value: 5000,
+        value: 10000,
         style: 'width: 100px; margin-right: 10px',
         options: [{
           value: 5000, label: '5,000bp'

--- a/public/js/p3/widget/CompareRegionViewer.js
+++ b/public/js/p3/widget/CompareRegionViewer.js
@@ -380,10 +380,48 @@ define([
       return parent.createPolyline(p2);
     },
 
-    make_rect: function (parent, x1, x2, height) {
+    make_rect: function (parent, x1, x2, height, radius) {
       var dat = {
         y: -height,
         height: 2 * height
+      };
+      if (x1 < x2) {
+        dat.x = x1;
+        dat.width = x2 - x1;
+      }
+      else {
+        dat.x = x2;
+        dat.width = x1 - x2;
+      }
+      dat.r = radius;
+
+      return parent.createRect(dat);
+    },
+
+    // Make a thin rounded rectangle for the blast hit
+    make_blast_rect: function (parent, x1, x2, height) {
+      var dat = {
+        y: -(height * .5),
+        height:  height
+      };
+      if (x1 < x2) {
+        dat.x = x1;
+        dat.width = x2 - x1;
+      }
+      else {
+        dat.x = x2;
+        dat.width = x1 - x2;
+      }
+      dat.r = height;
+
+      return parent.createRect(dat);
+    },
+
+    // Make a thin rectangle for the pg feature
+    make_pg_rect: function (parent, x1, x2, height) {
+      var dat = {
+        y: -(height * .5),
+        height:  height
       };
       if (x1 < x2) {
         dat.x = x1;
@@ -419,9 +457,8 @@ define([
         color = 'rgb(240,240,240)';
       }
       else {
-        glyph = this.make_rect(row, x1, x2, height);
-
         if (feature.type === 'blast') {
+          glyph = this.make_blast_rect(row, x1, x2, height);
           var sat = Math.trunc(feature.blast_identity);
 
           var rgb = this.hsvToRgb(0, sat, 100);
@@ -429,17 +466,26 @@ define([
           color = 'rgb(' + rgb[0] + ',' + rgb[1] + ',' + rgb[2] + ')';
           // console.log("have blast feature " + feature.blast_identity + " " + rgb + " " + color)
         }
+	else if (feature.type === 'pseudogene') {
+	  glyph = this.make_pg_rect(row, x1, x2, height);
+	}
+	else {
+	  glyph = this.make_rect(row, x1, x2, height);
+	}
+	  
       }
 
       /**
        * Pinned features are red.
        */
+      var pinned = 0;
       if (feature.fid == row_data.pinned_peg && typeof feature.blast_identity !== 'undefined') {
         var sat = Math.trunc(feature.blast_identity);
 
         var rgb = this.hsvToRgb(0, sat, 100);
 
         color = 'rgb(' + rgb[0] + ',' + rgb[1] + ',' + rgb[2] + ')';
+	pinned = 1;
       }
 
       if (feature.type !== 'intergenic') {
@@ -453,7 +499,9 @@ define([
 
           if (this.selected_fids[feature.fid]) {
             glyph.setStroke({ width: 3, cap: 'round' });
-          }
+          } else if (pinned) {
+	    glyph.setStroke({ width: 2, cap: 'round' });
+	  }
 
           if (typeof feature.set_number !== 'undefined') {
             var t = row.createText({ text: feature.set_number, align: 'center' });

--- a/public/js/p3/widget/PerspectiveToolTip.js
+++ b/public/js/p3/widget/PerspectiveToolTip.js
@@ -74,7 +74,8 @@ define([
       ],
       FeatureList: [
         { label: 'Overview', link: 'overview' },
-        { label: 'Features', link: 'features' }
+        { label: 'Features', link: 'features' },
+        { label: 'Compare regions', link: 'feature' }
       ]
     },
 

--- a/public/js/p3/widget/viewer/Feature.js
+++ b/public/js/p3/widget/viewer/Feature.js
@@ -163,10 +163,12 @@ define([
         });
         this.queryNode.innerHTML = out.join(' &raquo; ') + ' &raquo; ' + lang.replace('<a href="/view/Genome/{feature.genome_id}">{feature.genome_name}</a>', { feature: feature });
 
+/*
         if (taxon_lineage_names.includes('Viruses') && this.context === 'bacteria') {
           this.set('context', 'virus')
           this.changeToVirusContext();
         }
+	*/
       }));
 
       var content = [];

--- a/public/js/p3/widget/viewer/FeatureGroup.js
+++ b/public/js/p3/widget/viewer/FeatureGroup.js
@@ -1,11 +1,13 @@
 define([
   'dojo/_base/declare', 'dojo/_base/lang',
   './_FeatureList', './TabViewerBase',
-  '../FeatureListOverview', '../GroupFeatureGridContainer'
+  '../FeatureListOverview', '../GroupFeatureGridContainer',
+  '../CompareRegionContainer'
 ], function (
   declare, lang,
   FeatureList, TabViewerBase,
-  Overview, GroupFeatureGridContainer
+  Overview, GroupFeatureGridContainer,
+  CompareRegionContainer
 ) {
 
   return declare([FeatureList], {
@@ -102,8 +104,15 @@ define([
         })
       });
 
+      this.compareRegionViewer = new CompareRegionContainer({
+        title: 'Compare Region Viewer',
+        style: 'overflow-y:auto',
+        id: this.viewer.id + '_compareRegionViewer'
+      });
+
       this.viewer.addChild(this.overview);
       this.viewer.addChild(this.features);
+      this.viewer.addChild(this.compareRegionViewer);
     }
   });
 });

--- a/public/js/p3/widget/viewer/_FeatureList.js
+++ b/public/js/p3/widget/viewer/_FeatureList.js
@@ -4,6 +4,7 @@ define([
   'dijit/layout/ContentPane',
   './TabViewerBase',
   '../FeatureListOverview', '../FeatureGridContainer',
+  '../CompareRegionContainer',
   '../../util/PathJoin', '../../util/QueryToEnglish'
 ], function (
   declare, lang,
@@ -11,6 +12,7 @@ define([
   ContentPane,
   TabViewerBase,
   Overview, FeatureGridContainer,
+  CompareRegionContainer,
   PathJoin, QueryToEnglish
 ) {
 
@@ -85,6 +87,7 @@ define([
       switch (active) {
         case 'overview':
         case 'features':
+        case 'compareRegionViewer':
           activeTab.set('state', this.state); // lang.mixin({},this.state));
           break;
         default:
@@ -135,8 +138,16 @@ define([
         disabled: false
       });
 
+      this.compareRegionViewer = new CompareRegionContainer({
+        title: 'Compare Region Viewer',
+        style: 'overflow-y:auto',
+        id: this.viewer.id + '_compareRegionViewer'
+      });
+
+
       this.viewer.addChild(this.overview);
       this.viewer.addChild(this.features);
+      this.viewer.addChild(this.compareRegionViewer);
     },
 
     onSetTotalFeatures: function (attr, oldVal, newVal) {


### PR DESCRIPTION
Note - this turns compare regions back on for viruses since it is now useful with the large DNA viruses.

We also add compare regions to the feature list and feature group pages. 