### PR TITLE
Fix view of jobs that were copied into public workspace

### DIFF
--- a/public/js/p3/widget/WorkspaceBrowser.js
+++ b/public/js/p3/widget/WorkspaceBrowser.js
@@ -795,8 +795,9 @@ define([
         validTypes: ['Homology'],
         tooltip: 'View alignments'
       }, function (selection) {
-        // console.log("Current Container Widget: ", self.actionPanel.currentContainerWidget, "Slection: ", selection)
-        Topic.publish('/navigate', { href: '/view/Homology' + self.actionPanel.currentContainerWidget.path });
+	// console.log("Current Container Widget: ", self.actionPanel.currentContainerWidget, "Slection: ", selection)
+        var modPath = self.actionPanel.currentContainerWidget.path.replace(/^\/public/, "");
+        Topic.publish('/navigate', { href: '/view/Homology' + modPath });
       }, false);
 
 

--- a/public/js/p3/widget/viewer/JobResult.js
+++ b/public/js/p3/widget/viewer/JobResult.js
@@ -38,6 +38,15 @@ define([
     _setDataAttr: function (data) {
       this.data = data;
       // console.log("[JobResult] data: ", data);
+      if (data.autoMeta.parameters.output_path != data.path)
+      {
+	// console.log("Rewrite data path from", data.autoMeta.parameters.output_path, "to", data.path);
+	  
+	for (outfile of data.autoMeta.output_files)
+	{
+	  outfile[0] = outfile[0].replace(new RegExp('^' + data.autoMeta.parameters.output_path), data.path);
+	}
+      }
       this._hiddenPath = data.path + '.' + data.name;
       // console.log("[JobResult] Output Files: ", this.data.autoMeta.output_files);
       var _self = this;


### PR DESCRIPTION
Currently if a job was run by a user in a private workspace and copied to public, the job would not view properly.

This PR causes the job result list to be edited on load to point at the correct location.