### PR TITLE
Change behavior of global search for IDs (Not yet for production)

### DIFF
--- a/public/js/p3/WorkspaceManager.js
+++ b/public/js/p3/WorkspaceManager.js
@@ -142,7 +142,7 @@ define([
       reads: {
         label: 'Reads',
         formats: ['.fq', '.fastq', '.fa', '.fasta', '.gz', '.bz2'],
-        description: 'Reads must be in fasta or fastq format (typically .fa, .fasta, .fa, .fastq).  Genbank formatted files are not currently accepted.'
+        description: 'Reads must be in fasta or fastq format (typically .fa, .fasta, .fq, .fastq).  Genbank formatted files are not currently accepted.'
       },
       svg: {
         label: 'SVG Image',

--- a/public/js/p3/widget/templates/GlobalSearch.html
+++ b/public/js/p3/widget/templates/GlobalSearch.html
@@ -44,6 +44,8 @@
             <option value="option_or">Any term</option>
             <option value="option_and2">All exact terms</option>
             <option value="option_or2">Any exact term</option>
+            <option value="option_feature_ids">Feature ID match</option>
+            <option value="option_genome_ids">Genome ID match</option>
           </span>
         </td>
       </tr>


### PR DESCRIPTION
    Change the behavior of global search:
    
    Add an option Feature ID Match that looks for strings in the query that match feature IDs, and
    drive the browser directly to either the feature page, if a single feature was selected,
    or to the feature list page configured with the set of features.
    
    Add an option Genome ID Match that looks for strings in the query that match genome IDs, and
    drive the browser directly to either the genome page, if a single genome was selected,
    or to the genome list page configured with the set of genomes.
    
    If neither of these options was selected, but the query text includes either a feature ID or a
    genome ID, act as if the Feature ID Match or Genome ID Match option was selected.