### PR TITLE
default rnaseq host pipeline should be stringtie

### DIFF
--- a/public/js/p3/widget/app/Rnaseq.js
+++ b/public/js/p3/widget/app/Rnaseq.js
@@ -919,7 +919,7 @@ define([
       } else if (values.recipe == 'RNA-Rocket') {
         assembly_values.feature_count = 'cufflinks';
       } else { // host
-        assembly_values.feature_count = 'htseq';
+        assembly_values.feature_count = 'stringtie';
       }
 
       // target_genome


### PR DESCRIPTION
Making this parameterization explicit in the job call instead of implicit in the backend code.
@chris-c-thomas Needed for workshop.