### PR TITLE
COPY ROWS for tsv viewer. Changed descriptions.

### DIFF
--- a/public/js/p3/widget/ActionBar.js
+++ b/public/js/p3/widget/ActionBar.js
@@ -132,8 +132,8 @@ define([
 
         // if this is a tsv or csv table, hide copy folder, move, rename, delete, edit type buttons
         if ((this.currentContainerType == 'csvFeature' || this.currentContainerType == '') &&
-          (act.options.label == 'DELETE' || act.options.label == 'MOVE' || act.options.label == 'RENAME' || act.options.label == 'EDIT TYPE' || act.options.label == 'DWNLD' ||
-            (act.options.label == 'COPY' && act.options.validContainerTypes != 'csvFeature'))) {
+          (act.options.label == 'DELETE' || act.options.label == 'MOVE' || act.options.label == 'RENAME' ||
+            act.options.label == 'EDIT TYPE' || act.options.label == 'DWNLD' || act.options.label == 'COPY')) {
           return false;
         }
 

--- a/public/js/p3/widget/CopyTooltipDialog.js
+++ b/public/js/p3/widget/CopyTooltipDialog.js
@@ -162,10 +162,10 @@ define([
       domConstruct.create('td', { style: 'width:10px;' }, tr);
       this.otherCopyNode = domConstruct.create('td', { style: 'vertical-align:top;' }, tr);
 
-      domConstruct.create('div', { 'class': 'wsActionTooltip', rel: 'full_w_header', innerHTML: 'Full Table (with headers)' }, tData);
-      domConstruct.create('div', { 'class': 'wsActionTooltip', rel: 'full_wo_header', innerHTML: 'Full Table (without headers)' }, tData);
-      domConstruct.create('div', { 'class': 'wsActionTooltip', rel: 'selected_w_header', innerHTML: 'Selected Rows (with headers)' }, tData);
-      domConstruct.create('div', { 'class': 'wsActionTooltip', rel: 'selected_wo_header', innerHTML: 'Selected Rows (without headers)' }, tData);
+      domConstruct.create('div', { 'class': 'wsActionTooltip', rel: 'full_w_header', innerHTML: 'All Columns (with headers)' }, tData);
+      domConstruct.create('div', { 'class': 'wsActionTooltip', rel: 'full_wo_header', innerHTML: 'All Columns (without headers)' }, tData);
+      domConstruct.create('div', { 'class': 'wsActionTooltip', rel: 'selected_w_header', innerHTML: 'Selected Columns (with headers)' }, tData);
+      domConstruct.create('div', { 'class': 'wsActionTooltip', rel: 'selected_wo_header', innerHTML: 'Selected Columns (without headers)' }, tData);
 
       tr = domConstruct.create('tr', {}, table);
       domConstruct.create('td', { colspan: 3, style: 'text-align:right' }, tr);

--- a/public/js/p3/widget/GridContainer.js
+++ b/public/js/p3/widget/GridContainer.js
@@ -384,7 +384,7 @@ define([
         'CopySelection',
         'fa icon-clipboard2 fa-2x',
         {
-          label: 'COPY',
+          label: 'COPY ROWS',
           multiple: true,
           validTypes: ['*'],
           ignoreDataType: true,
@@ -979,7 +979,7 @@ define([
               });
 
               return;
-              // break;
+            // break;
             case 'pathway_data':
               var queryContext = containerWidget.grid.store.state.search;
               switch (containerWidget.type) {
@@ -1010,7 +1010,7 @@ define([
                     });
                   });
                   return;
-                  // break;
+                // break;
                 case 'ec_number':
                   var ec_numbers = selection.map(function (d) {
                     return d.ec_number;
@@ -1039,7 +1039,7 @@ define([
                   });
 
                   return;
-                  // break;
+                // break;
                 case 'gene':
                   ids = selection.map(function (d) {
                     return d.feature_id;
@@ -1047,7 +1047,7 @@ define([
                   break;
                 default:
                   return;
-                  // break;
+                // break;
               }
               break;
             default:
@@ -1174,7 +1174,7 @@ define([
               });
 
               return;
-              // break;
+            // break;
             case 'pathway_data':
 
               var queryContext = containerWidget.grid.store.state.search;
@@ -1207,7 +1207,7 @@ define([
                     });
                   });
                   return;
-                  // break;
+                // break;
                 case 'ec_number':
                   var ec_numbers = selection.map(function (d) {
                     return d.ec_number;
@@ -1233,7 +1233,7 @@ define([
                   });
 
                   return;
-                  // break;
+                // break;
                 case 'gene':
                   ids = selection.map(function (d) {
                     return d.feature_id;
@@ -1241,7 +1241,7 @@ define([
                   break;
                 default:
                   return;
-                  // break;
+                // break;
               }
               break;
             default:

--- a/public/js/p3/widget/WorkspaceBrowser.js
+++ b/public/js/p3/widget/WorkspaceBrowser.js
@@ -1182,7 +1182,7 @@ define([
         if (this.selection[0].type.includes('dna')) {
           alignType = 'dna';
         }
-        console.log('container ',container);
+        console.log('container ', container);
         var afa_file;
         var exist_nwk = 0;
 
@@ -2138,7 +2138,9 @@ define([
 
             if (this.actionPanel) {
               this.actionPanel.set('currentContainerWidget', newPanel);
-              this.itemDetailPanel.set('containerWidget', newPanel);
+              if (this.itemDetailPanel) {
+                this.itemDetailPanel.set('containerWidget', newPanel);
+              }
             }
 
             if (newPanel.on) {

--- a/public/js/p3/widget/viewer/TSV_CSV.js
+++ b/public/js/p3/widget/viewer/TSV_CSV.js
@@ -258,14 +258,14 @@ define([
 
       // add copy button to action panel
       this.actionPanel.addAction('CopySelection', 'fa icon-clipboard2 fa-2x', {
-        label: 'COPY',
+        label: 'COPY ROWS',
         multiple: true,
         validTypes: ['*'],
         ignoreDataType: true,
         tooltip: 'Copy Selection to Clipboard.',
         tooltipDialog: copySelectionTT,
         max: 5000,
-        validContainerTypes: ['csvFeature']
+        validContainerTypes: ['csvFeature', '']
       },
         function (selection, container) {
           _self.actionPanel._actions.CopySelection.options.tooltipDialog.set('selection', selection);


### PR DESCRIPTION
1. Renamed an action panel button to COPY ROWS to distinguish it from COPY.
2. Got it to work for generic TSV viewers by adding a '' (empty) type.
3. Changed the description of the drop down items to refer to copying columns, since that is where the items differ. This avoids confusion, since I was confused by it.