### PR TITLE
Fix: Prevent LinkedIn OAuth token exposure in error responses (TIKI-W094-13)

### DIFF
--- a/routes/linkedin.js
+++ b/routes/linkedin.js
@@ -106,8 +106,14 @@ router.get('/posts', async function (req, res) {
     }).then(response => {
       res.send(response.data);
     }).catch(error => {
+      // Log full error server-side for debugging (never expose to client)
+      console.error('LinkedIn API error:', error.message);
+
+      // Return only a generic error message to the client
+      // Never send the raw error object as it may contain sensitive data
+      // such as Authorization headers with Bearer tokens
       res.status(400).send({
-        message: error
+        message: 'Failed to retrieve LinkedIn posts'
       });
     });
   } catch (e) {


### PR DESCRIPTION
## Summary
- **Security fix for CVSS 7.3 vulnerability (TIKI-W094-13)**
- The `/linkedin/posts/` endpoint was returning raw Axios error objects to clients
- These error objects contained the full request configuration including `Authorization: Bearer <token>` headers
- Attackers could trigger errors via resource exhaustion (~100 rapid requests) and extract the LinkedIn OAuth token

## Changes
- Replace raw error object with generic error message: "Failed to retrieve LinkedIn posts"
- Add server-side logging for debugging
- Add comments explaining the security rationale

## Test plan
- [ ] Verify `/linkedin/posts/` endpoint returns generic error message on failure
- [ ] Verify server logs contain the actual error details for debugging
- [ ] Confirm no sensitive data (tokens, headers) appears in client responses

## Additional recommendations
- **Immediately revoke and rotate the exposed LinkedIn access token**
- Consider adding rate limiting to the `/linkedin/posts/` endpoint
- Audit other error handlers in the codebase for similar patterns

🤖 Generated with [Claude Code](https://claude.ai/code)