### PR TITLE
Add hotfix workflow for production fixes

### DIFF
--- a/.github/workflows/hotfix-tag.yml
+++ b/.github/workflows/hotfix-tag.yml
@@ -1,0 +1,81 @@
+name: Tag Hotfix
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  tag-hotfix:
+    # Only run if PR was merged and branch name starts with hotfix/v
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'hotfix/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Create and push tag
+        run: |
+          # Extract version from branch name (hotfix/vX.X.X -> vX.X.X)
+          VERSION=$(echo "${{ github.event.pull_request.head.ref }}" | sed 's/hotfix\///')
+          # Use PR title as tag message
+          git tag -a "$VERSION" -m "${{ github.event.pull_request.title }}"
+          git push origin "$VERSION"
+          echo "Created and pushed tag: $VERSION"
+
+      - name: Cherry-pick to alpha
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Get the merge commit SHA
+          MERGE_COMMIT=${{ github.event.pull_request.merge_commit_sha }}
+          VERSION=$(echo "${{ github.event.pull_request.head.ref }}" | sed 's/hotfix\///')
+
+          # Fetch alpha branch
+          git fetch origin alpha
+          git checkout alpha
+
+          # Cherry-pick the commits from the hotfix (excluding merge commit itself)
+          # Get the commits that were in the PR
+          git cherry-pick -x $MERGE_COMMIT -m 1 || {
+            echo "Cherry-pick had conflicts. Creating a PR for manual resolution."
+            git cherry-pick --abort
+
+            # Create a branch for manual cherry-pick
+            git checkout -b cherry-pick/hotfix-${VERSION}
+            git push -u origin cherry-pick/hotfix-${VERSION}
+
+            gh pr create --base alpha --head cherry-pick/hotfix-${VERSION} \
+              --title "Cherry-pick: Hotfix ${VERSION} to alpha" \
+              --body "## Cherry-pick Hotfix ${VERSION}
+
+          The automatic cherry-pick had conflicts. Please manually apply the changes from the hotfix.
+
+          Original PR: #${{ github.event.pull_request.number }}
+          Merge commit: ${MERGE_COMMIT}
+
+          ---
+          *This PR was created automatically because the cherry-pick had conflicts.*"
+            exit 0
+          }
+
+          # Push the cherry-picked commit to alpha
+          git push origin alpha
+          echo "Successfully cherry-picked hotfix to alpha"
+
+      - name: Delete hotfix branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          BRANCH="${{ github.event.pull_request.head.ref }}"
+          gh api -X DELETE "repos/${{ github.repository }}/git/refs/heads/${BRANCH}" || true
+          echo "Deleted branch: $BRANCH"

--- a/.github/workflows/hotfix.yml
+++ b/.github/workflows/hotfix.yml
@@ -1,0 +1,60 @@
+name: Hotfix
+on:
+  workflow_dispatch:
+    inputs:
+      hotfix_message:
+        description: 'Hotfix description (what is being fixed)'
+        required: true
+        type: string
+
+jobs:
+  create-hotfix:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Bump patch version and create hotfix branch
+        id: bump
+        run: |
+          npm version patch --no-git-tag-version
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          git checkout -b hotfix/v${VERSION}
+          git add package.json package-lock.json
+          git commit -m "Hotfix v${VERSION}
+
+          ${{ inputs.hotfix_message }}"
+
+      - name: Push branch and create PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION=${{ steps.bump.outputs.version }}
+          # Delete the branch if it already exists (from a failed previous run)
+          git push origin --delete hotfix/v${VERSION} 2>/dev/null || true
+          git push -u origin hotfix/v${VERSION}
+          gh pr create --base main --head hotfix/v${VERSION} \
+            --title "Hotfix v${VERSION}" \
+            --body "## Hotfix v${VERSION}
+
+          ${{ inputs.hotfix_message }}
+
+          ---
+          **Next steps:**
+          1. Check out this branch locally: \`git fetch origin && git checkout hotfix/v${VERSION}\`
+          2. Make your fix commits
+          3. Push your changes: \`git push\`
+          4. Merge this PR when ready
+
+          *After merging, a tag will be created and changes will be cherry-picked to alpha.*"


### PR DESCRIPTION
## Summary
- Adds `hotfix.yml`: Creates hotfix branch from main, bumps patch version, opens PR
- Adds `hotfix-tag.yml`: Tags release after merge, cherry-picks to alpha, cleans up branch

This enables applying urgent security fixes to production (main) without waiting for unready work queued in alpha.

Ported from MAAGE-BRC/MAAGE-Web PR #88, adapted for BV-BRC-Web branch structure:
- Uses `alpha` instead of `dev` as development branch
- Uses `actions/checkout@v4` to match existing workflows

## Test plan
- [ ] Run the Hotfix workflow manually from Actions tab
- [ ] Verify PR is created against main with correct instructions
- [ ] Merge and verify tag is created and cherry-pick to alpha succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)