### PR TITLE
Add hotfix workflows to alpha with version fix

### DIFF
--- a/.github/workflows/hotfix-tag.yml
+++ b/.github/workflows/hotfix-tag.yml
@@ -1,0 +1,81 @@
+name: Tag Hotfix
+on:
+  pull_request:
+    types: [closed]
+    branches: [master]
+
+jobs:
+  tag-hotfix:
+    # Only run if PR was merged and branch name starts with hotfix/v
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'hotfix/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: master
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Create and push tag
+        run: |
+          # Extract version from branch name (hotfix/vX.X.X -> vX.X.X)
+          VERSION=$(echo "${{ github.event.pull_request.head.ref }}" | sed 's/hotfix\///')
+          # Use PR title as tag message
+          git tag -a "$VERSION" -m "${{ github.event.pull_request.title }}"
+          git push origin "$VERSION"
+          echo "Created and pushed tag: $VERSION"
+
+      - name: Cherry-pick to alpha
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Get the merge commit SHA
+          MERGE_COMMIT=${{ github.event.pull_request.merge_commit_sha }}
+          VERSION=$(echo "${{ github.event.pull_request.head.ref }}" | sed 's/hotfix\///')
+
+          # Fetch alpha branch
+          git fetch origin alpha
+          git checkout alpha
+
+          # Cherry-pick the commits from the hotfix (excluding merge commit itself)
+          # Get the commits that were in the PR
+          git cherry-pick -x $MERGE_COMMIT -m 1 || {
+            echo "Cherry-pick had conflicts. Creating a PR for manual resolution."
+            git cherry-pick --abort
+
+            # Create a branch for manual cherry-pick
+            git checkout -b cherry-pick/hotfix-${VERSION}
+            git push -u origin cherry-pick/hotfix-${VERSION}
+
+            gh pr create --base alpha --head cherry-pick/hotfix-${VERSION} \
+              --title "Cherry-pick: Hotfix ${VERSION} to alpha" \
+              --body "## Cherry-pick Hotfix ${VERSION}
+
+          The automatic cherry-pick had conflicts. Please manually apply the changes from the hotfix.
+
+          Original PR: #${{ github.event.pull_request.number }}
+          Merge commit: ${MERGE_COMMIT}
+
+          ---
+          *This PR was created automatically because the cherry-pick had conflicts.*"
+            exit 0
+          }
+
+          # Push the cherry-picked commit to alpha
+          git push origin alpha
+          echo "Successfully cherry-picked hotfix to alpha"
+
+      - name: Delete hotfix branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          BRANCH="${{ github.event.pull_request.head.ref }}"
+          gh api -X DELETE "repos/${{ github.repository }}/git/refs/heads/${BRANCH}" || true
+          echo "Deleted branch: $BRANCH"

--- a/.github/workflows/hotfix.yml
+++ b/.github/workflows/hotfix.yml
@@ -1,0 +1,78 @@
+name: Hotfix
+on:
+  workflow_dispatch:
+    inputs:
+      hotfix_message:
+        description: 'Hotfix description (what is being fixed)'
+        required: true
+        type: string
+
+jobs:
+  create-hotfix:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: master
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Get version from alpha and bump patch
+        id: bump
+        run: |
+          # Fetch alpha branch to get the current version (alpha is the source of truth)
+          git fetch origin alpha
+
+          # Get the version from alpha's package.json
+          ALPHA_VERSION=$(git show origin/alpha:package.json | node -p "JSON.parse(require('fs').readFileSync('/dev/stdin', 'utf8')).version")
+          echo "Alpha version: $ALPHA_VERSION"
+
+          # Parse version components
+          MAJOR=$(echo $ALPHA_VERSION | cut -d. -f1)
+          MINOR=$(echo $ALPHA_VERSION | cut -d. -f2)
+          PATCH=$(echo $ALPHA_VERSION | cut -d. -f3)
+
+          # Bump patch version
+          NEW_PATCH=$((PATCH + 1))
+          VERSION="${MAJOR}.${MINOR}.${NEW_PATCH}"
+          echo "New hotfix version: $VERSION"
+
+          # Update package.json with the new version
+          npm version $VERSION --no-git-tag-version --allow-same-version
+
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          git checkout -b hotfix/v${VERSION}
+          git add package.json package-lock.json
+          git commit -m "Hotfix v${VERSION}
+
+          ${{ inputs.hotfix_message }}"
+
+      - name: Push branch and create PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION=${{ steps.bump.outputs.version }}
+          # Delete the branch if it already exists (from a failed previous run)
+          git push origin --delete hotfix/v${VERSION} 2>/dev/null || true
+          git push -u origin hotfix/v${VERSION}
+          gh pr create --base master --head hotfix/v${VERSION} \
+            --title "Hotfix v${VERSION}" \
+            --body "## Hotfix v${VERSION}
+
+          ${{ inputs.hotfix_message }}
+
+          ---
+          **Next steps:**
+          1. Check out this branch locally: \`git fetch origin && git checkout hotfix/v${VERSION}\`
+          2. Make your fix commits
+          3. Push your changes: \`git push\`
+          4. Merge this PR when ready
+
+          *After merging, a tag will be created and changes will be cherry-picked to alpha.*"


### PR DESCRIPTION
## Summary
- Adds hotfix.yml and hotfix-tag.yml workflows to alpha branch
- Fixes version conflict issue: workflow now fetches version from alpha (source of truth) instead of master

## Problem
The original hotfix workflow used master package.json version to determine the next hotfix version. But master is always behind alpha, so hotfix versions would clash with existing release tags.

## Solution
The workflow now:
1. Fetches the alpha branch
2. Reads the version from alpha package.json
3. Bumps the patch version from there

This ensures hotfix versions are always newer than any existing release.

## Test plan
- [ ] Merge this PR
- [ ] Trigger the Hotfix workflow from Actions tab
- [ ] Verify the version is based on alpha version + 1 patch

Generated with Claude Code