### PR TITLE
Cherry-pick security fixes to beta

### DIFF
--- a/public/js/p3/app/app.js
+++ b/public/js/p3/app/app.js
@@ -120,6 +120,12 @@ define([
       });
 
       on(window, 'message', function (evt) {
+        // Security: Only accept postMessages from same origin to prevent XSS
+        // via malicious cross-origin messages (TIKI-W094-1)
+        if (evt.origin !== window.location.origin) {
+          return;
+        }
+
         var msg = evt.data;
         // console.log("window.message: ", msg);
         /* istanbul ignore else */
@@ -286,8 +292,13 @@ define([
       });
       /* istanbul ignore next */
       on(window, 'message', function (msg) {
-        // console.log('onMessage: ', msg);
-        if (msg && (msg.data === 'RemoteReady' || !msg.data || msg.origin=="https://syndication.twitter.com")) {
+        // Security: Only accept postMessages from same origin (TIKI-W094-1)
+        if (!msg || !msg.data || msg.origin !== window.location.origin) {
+          return;
+        }
+
+        // Additional validation for string JSON messages
+        if (typeof msg.data !== 'string' || !msg.data.trim().startsWith('{')) {
           return;
         }
 
@@ -298,7 +309,7 @@ define([
            Topic.publish(msg.topic, msg.payload);
           }
         } catch (err){
-          console.log("Error handling window message: ", msg,err)
+          // Silently ignore parse errors from non-JSON messages
         }
       }, '*');
 

--- a/routes/linkedin.js
+++ b/routes/linkedin.js
@@ -106,8 +106,14 @@ router.get('/posts', async function (req, res) {
     }).then(response => {
       res.send(response.data);
     }).catch(error => {
+      // Log full error server-side for debugging (never expose to client)
+      console.error('LinkedIn API error:', error.message);
+
+      // Return only a generic error message to the client
+      // Never send the raw error object as it may contain sensitive data
+      // such as Authorization headers with Bearer tokens
       res.status(400).send({
-        message: error
+        message: 'Failed to retrieve LinkedIn posts'
       });
     });
   } catch (e) {


### PR DESCRIPTION
## Summary
Cherry-pick two security fixes from master to beta:

- **TIKI-W094-1** (CVSS 6.1): Fix DOM XSS via postMessage vulnerability
- **TIKI-W094-13** (CVSS 7.3): Fix LinkedIn OAuth token exposure in error responses

## Commits
- b57b73c02 Fix DOM XSS via postMessage vulnerability (TIKI-W094-1)
- 2b1551be2 Fix: Prevent LinkedIn OAuth token exposure in error responses (TIKI-W094-13)

Generated with Claude Code