### PR TITLE
Cherry-pick: Hotfix v3.57.30 focus-stealing fix to beta

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,3 +218,72 @@ Configured in `p3-web.conf`:
 - App Service: Job submission
 - Homology Service: BLAST searches
 - Compare Regions: Genome comparison
+
+## Dijit Form Validation Patterns
+
+When working with dijit form validation, be aware of these key behaviors:
+
+### Form Validation and Focus
+When `dijit/form/Form.validate()` is called (which happens on every keystroke if `intermediateChanges: true`):
+1. It iterates through all form widgets calling `isValid()`
+2. If a widget returns `false`, the Form **scrolls to it and calls `focus()`**
+3. This can steal focus from the field the user is currently typing in
+
+**Solution:** Override `focus()` in widgets that shouldn't receive automatic focus:
+```javascript
+focus: function () {
+  // Only focus if user explicitly initiated it
+  if (this._userInitiatedFocus) {
+    this._userInitiatedFocus = false;
+    this.searchBox.focus();
+  }
+  // Otherwise, block automatic focus from form validation
+}
+```
+
+### Making Custom Widgets Participate in Form Validation
+To make a custom widget participate in dijit form validation:
+1. Add `dijit/form/_FormValueMixin` to the widget's declare chain
+2. Implement `isValid(isFocused)` method that returns boolean
+3. Implement `validate(isFocused)` method for visual feedback
+4. Ensure the widget has a `name` attribute in the template
+
+**Warning:** Adding `_FormValueMixin` makes the widget subject to Form's focus-stealing behavior.
+
+### Validation Order Matters
+When validating optional fields, check if the field is required/empty **before** calling inner widget's `isValid()`:
+```javascript
+validate: function (isFocused) {
+  // Check optional empty FIRST - return early to avoid inner validation
+  if (!this.required) {
+    var value = this.get('value') || '';
+    if (!value || value === '') {
+      return true;  // Optional empty = valid
+    }
+  }
+  // Only now check inner widget (which might return false for empty)
+  return this.innerWidget.isValid(isFocused);
+}
+```
+
+### Dijit Error Styling
+To show validation errors visually without triggering dijit side effects:
+```javascript
+// DO: Just add CSS classes
+domClass.add(widget.domNode, 'dijitError');
+domClass.add(widget.domNode, 'dijitTextBoxError');
+
+// DON'T: Manipulate dijit internal state (can cause focus issues)
+widget._set('state', 'Error');
+widget._hasBeenBlurred = true;  // Can trigger refresh/focus behavior
+```
+
+### Widget Lifecycle and Null Checks
+Widgets created conditionally (e.g., only when user is logged in) may not exist during early validation:
+```javascript
+// In startup() - widget may not exist yet
+this.inherited(arguments);  // Calls validate()
+
+// In validate() - always check existence
+var value = this.optionalWidget ? this.optionalWidget.get('value') : '';
+```

--- a/public/js/p3/widget/WorkspaceObjectSelector.js
+++ b/public/js/p3/widget/WorkspaceObjectSelector.js
@@ -1278,18 +1278,14 @@ define([
       this.searchBox.set('placeHolder', this.placeHolder);
       this.searchBox.labelFunc = this.labelFunc;
 
-      // Re-validate when the searchBox dropdown closes or loses focus
-      // This ensures error state is restored after user interaction
+      // Re-validate when the searchBox dropdown closes
+      // This ensures error state is restored after user interaction with the dropdown
       var self = this;
       if (this.searchBox.dropDown) {
         on(this.searchBox.dropDown, 'hide', function() {
           setTimeout(function() { self.validate(); }, 0);
         });
       }
-      // Handle blur event on the searchBox
-      on(this.searchBox, 'blur', function() {
-        setTimeout(function() { self.validate(); }, 0);
-      });
       // Handle when dropdown closes (closeDropDown is called)
       var originalCloseDropDown = this.searchBox.closeDropDown;
       if (originalCloseDropDown) {
@@ -1365,21 +1361,33 @@ define([
     },
 
     validate: function (/* Boolean */ isFocused) {
-      // possibly need to build out refresh function to prevent tricky submissions(see validationtextbox)
-      var isValid = this.disabled || this.searchBox.isValid(isFocused);
+      // First check: if disabled, always valid
+      if (this.disabled) {
+        return true;
+      }
 
-      // If not required and value is empty, consider it valid
-      // This handles cases where the widget is optional (like fasta selector in Similar Genome Finder)
-      if (!this.required && !this.disabled) {
+      // Second check: if not required and value is empty, it's valid
+      // This must be checked BEFORE calling searchBox.isValid() to avoid
+      // the form focusing on empty optional fields
+      if (!this.required) {
         var currentValue = this.get('value') || '';
         if (!currentValue || currentValue === '' || currentValue === '/' || currentValue === '__loading__') {
-          // Empty optional field is valid
-          isValid = true;
+          // Empty optional field is valid - no need for visual error state
+          this._set('state', '');
+          this.focusNode.setAttribute('aria-invalid', 'false');
+          if (this.searchBox && this.searchBox.domNode) {
+            domClass.remove(this.searchBox.domNode, 'dijitError');
+            domClass.remove(this.searchBox.domNode, 'dijitTextBoxError');
+          }
+          return true;
         }
       }
 
+      // Now check the searchBox's validity
+      var isValid = this.searchBox.isValid(isFocused);
+
       // Additional check: if required, ensure value is not empty and is a valid path
-      if (isValid && this.required && !this.disabled) {
+      if (isValid && this.required) {
         var currentValue = this.get('value') || '';
         // Check for empty value or invalid paths
         // A valid workspace path should have at least 4 parts: ['', 'user', 'workspace', 'folder']
@@ -1405,34 +1413,21 @@ define([
       // Force the searchBox's visual validation state to match our validation result
       // This ensures the red border appears when validation fails, even if the
       // searchBox's own validation would pass (e.g., empty but not focused yet)
-      if (this.searchBox) {
+      // Note: We only manipulate CSS classes, not dijit's internal state, to avoid
+      // triggering focus-related side effects during validation
+      if (this.searchBox && this.searchBox.domNode) {
         if (!isValid) {
-          // Force error state on searchBox
-          this.searchBox._set('state', 'Error');
-          // Set _hasBeenBlurred so dijit will show the error styling
-          // Without this, dijit won't show error state on fields that haven't been touched
-          this.searchBox._hasBeenBlurred = true;
           // Add error classes to show visual feedback
           // The claro theme uses dijitTextBoxError for the red border
-          if (this.searchBox.domNode) {
-            domClass.add(this.searchBox.domNode, 'dijitError');
-            domClass.add(this.searchBox.domNode, 'dijitTextBoxError');
-          }
+          domClass.add(this.searchBox.domNode, 'dijitError');
+          domClass.add(this.searchBox.domNode, 'dijitTextBoxError');
         } else {
-          // Clear error state on searchBox
-          this.searchBox._set('state', '');
-          if (this.searchBox.domNode) {
-            domClass.remove(this.searchBox.domNode, 'dijitError');
-            domClass.remove(this.searchBox.domNode, 'dijitTextBoxError');
-          }
+          // Clear error classes
+          domClass.remove(this.searchBox.domNode, 'dijitError');
+          domClass.remove(this.searchBox.domNode, 'dijitTextBoxError');
         }
       }
 
-      if (isValid) {
-        registry.byClass('p3.widget.WorkspaceFilenameValidationTextBox').forEach(function (obj) {
-          obj.validate();
-        });
-      }
       return isValid;
     },
 
@@ -1440,6 +1435,21 @@ define([
       // This method is called by dijit/form/Form.validate() to check if this widget is valid
       // It delegates to our validate() method which handles the actual validation logic
       return this.validate(isFocused);
+    },
+
+    // Override focus to prevent Form.validate() from stealing focus when it finds
+    // an invalid widget. The Form calls focus() on the first invalid widget,
+    // which disrupts user input in other fields.
+    focus: function () {
+      // Only focus if this widget is the active element or user explicitly clicked
+      // Don't auto-focus during form validation
+      if (this._userInitiatedFocus) {
+        this._userInitiatedFocus = false;
+        if (this.searchBox && this.searchBox.focus) {
+          this.searchBox.focus();
+        }
+      }
+      // Otherwise, do nothing - prevent form validation from stealing focus
     },
 
     sanitizeSelection: function (path) {

--- a/public/js/p3/widget/WorkspaceObjectSelector.js
+++ b/public/js/p3/widget/WorkspaceObjectSelector.js
@@ -1368,6 +1368,16 @@ define([
       // possibly need to build out refresh function to prevent tricky submissions(see validationtextbox)
       var isValid = this.disabled || this.searchBox.isValid(isFocused);
 
+      // If not required and value is empty, consider it valid
+      // This handles cases where the widget is optional (like fasta selector in Similar Genome Finder)
+      if (!this.required && !this.disabled) {
+        var currentValue = this.get('value') || '';
+        if (!currentValue || currentValue === '' || currentValue === '/' || currentValue === '__loading__') {
+          // Empty optional field is valid
+          isValid = true;
+        }
+      }
+
       // Additional check: if required, ensure value is not empty and is a valid path
       if (isValid && this.required && !this.disabled) {
         var currentValue = this.get('value') || '';

--- a/public/js/p3/widget/app/GenomeDistance.js
+++ b/public/js/p3/widget/app/GenomeDistance.js
@@ -99,7 +99,8 @@ define([
     validate: function () {
       // console.log("validate", this.genome_id.get('value'), this.fasta.get('value'), !(this.genome_id.get('value') == '' && this.fasta.get('value') == ''));
       var input_genome_valid = this.genome_id.get('value') != '';
-      var input_fasta_valid = this.fasta.get('value') != '';
+      // Check if fasta selector exists (it's only created when user is logged in)
+      var input_fasta_valid = this.fasta ? this.fasta.get('value') != '' : false;
       var input_valid = (input_genome_valid && !input_fasta_valid) || (!input_genome_valid && input_fasta_valid);
 
       var bac = this.org_bacterial.get('value');


### PR DESCRIPTION
## Cherry-pick Hotfix v3.57.30 to beta

This PR cherry-picks the focus-stealing prevention fixes from v3.57.30 to beta.

### Problem Fixed
When typing in form fields (like Output Name), form validation on each keystroke
would cause dijit Form to scroll to and focus on invalid WorkspaceObjectSelector
widgets, making it impossible to type more than one character at a time.

### Changes
1. Fix validation for optional WorkspaceObjectSelector widgets
   - Added null check for optional widgets in GenomeDistance.js
   - Fixed validation to return early for optional empty fields

2. Prevent form validation from stealing focus
   - Added focus() override to block automatic focus from form validation
   - Simplified CSS error class manipulation
   - Updated CLAUDE.md with dijit form validation patterns

---
*Cherry-picked from hotfix/v3.57.30 commits fab0e81b8 and 3e175d4b6*