### PR TITLE
Fix output folder dropdown: top-level workspaces and cross-workspace favorites

### DIFF
--- a/public/js/p3/widget/WorkspaceObjectSelector.js
+++ b/public/js/p3/widget/WorkspaceObjectSelector.js
@@ -1131,7 +1131,14 @@ define([
             });
 
             // Combine: favorites first, then regular items
-            var combinedItems = favoriteItems.concat(regularItems);
+            // Filter out items with invalid paths before adding to store
+            // (items with 'undefined' or fewer than 3 path parts are not selectable)
+            var combinedItems = favoriteItems.concat(regularItems).filter(function (item) {
+              if (!item.path) return false;
+              if (item.path.indexOf('undefined') !== -1) return false;
+              if (item.path.split('/').length < 3) return false;
+              return true;
+            });
 
             this.store = new Memory({ data: combinedItems, idProperty: 'path' });
             if (this.isSortAlpha) {
@@ -1317,21 +1324,11 @@ define([
         return '<div style="font-size:1em; color:#666; padding:8px;">Loading folders...</div>';
       }
 
-      // Filter out invalid items containing 'undefined' in the path
-      if (item.path && item.path.indexOf('undefined') !== -1) {
-        return '<div style="display:none;"></div>';
-      }
-
       // Add star icon for favorite items
       var starIcon = item.isFavorite ? '<i class="icon-star" style="color:#f0ad4e;margin-right:4px;"></i>' : '';
 
       var label = '<div style="font-size:1em; border-bottom:1px solid grey;">' + starIcon + '/';
       var pathParts = item.path.split('/');
-
-      // Hide items with fewer than 3 parts (just /user)
-      if (pathParts.length < 3) {
-        return '<div style="display:none;"></div>';
-      }
 
       var workspace = pathParts[2]; // workspace name (e.g., 'home', 'test')
 

--- a/public/js/p3/widget/WorkspaceObjectSelector.js
+++ b/public/js/p3/widget/WorkspaceObjectSelector.js
@@ -999,15 +999,18 @@ define([
           var items = results[0];
           var favoritePaths = results[1] || [];
 
+          // Normalize paths by stripping trailing slashes for consistent comparison
+          function normPath(p) { return p ? p.replace(/\/+$/, '') : ''; }
+
           // Create a Set for fast lookup of items we already have
           var itemPathSet = {};
           items.forEach(function (item) {
-            itemPathSet[item.path] = true;
+            itemPathSet[normPath(item.path)] = true;
           });
 
           // Find favorite paths that are NOT in the items list (from other workspaces)
           var missingFavoritePaths = favoritePaths.filter(function (path) {
-            return !itemPathSet[path];
+            return !itemPathSet[normPath(path)];
           });
 
           // If there are missing favorites, fetch their metadata
@@ -1085,17 +1088,17 @@ define([
               });
             }
 
-            // Create a Set for fast lookup of favorite paths
+            // Create a Set for fast lookup of favorite paths (normalized)
             var favoriteSet = {};
             favoritePaths.forEach(function (path) {
-              favoriteSet[path] = true;
+              favoriteSet[normPath(path)] = true;
             });
 
             // Mark items that are favorites and separate into two arrays
             var favoriteItems = [];
             var regularItems = [];
             items.forEach(function (item) {
-              if (favoriteSet[item.path]) {
+              if (favoriteSet[normPath(item.path)]) {
                 item.isFavorite = true;
                 favoriteItems.push(item);
               } else {
@@ -1103,19 +1106,20 @@ define([
               }
             });
 
-            // Add missing favorites (from other workspaces) to the favorites list
+            // Add missing favorites (from other workspaces), skipping any already present
+            var seenPaths = {};
+            favoriteItems.forEach(function (item) { seenPaths[normPath(item.path)] = true; });
             missingFavorites.forEach(function (meta) {
-              // Strip trailing slash from path for consistent formatting
-              var cleanPath = meta.path.replace(/\/+$/, '');
-              // Convert metadata to item format with timestamp
-              var item = {
+              var cleanPath = normPath(meta.path);
+              if (seenPaths[cleanPath]) return;
+              seenPaths[cleanPath] = true;
+              favoriteItems.push({
                 path: cleanPath,
                 name: meta.name,
                 type: meta.type,
                 timestamp: meta.creation_time ? new Date(meta.creation_time).getTime() : 0,
                 isFavorite: true
-              };
-              favoriteItems.push(item);
+              });
             });
 
             // Sort favorites alphabetically
@@ -1331,9 +1335,9 @@ define([
 
       var workspace = pathParts[2]; // workspace name (e.g., 'home', 'test')
 
-      // Top-level workspace (e.g., /user/test) — show workspace name as the label
+      // Top-level workspace (e.g., /user/test) — show as "/test"
       if (pathParts.length === 3) {
-        label += '</br><span style="font-size:1.05em; font-weight:bold;" title="/' + workspace + '">' + workspace + '</span></div>';
+        label += '<span style="font-size:1.05em; font-weight:bold;" title="/' + workspace + '">' + workspace + '</span></div>';
         return label;
       }
 

--- a/public/js/p3/widget/WorkspaceObjectSelector.js
+++ b/public/js/p3/widget/WorkspaceObjectSelector.js
@@ -1110,7 +1110,8 @@ define([
             var seenPaths = {};
             favoriteItems.forEach(function (item) { seenPaths[normPath(item.path)] = true; });
             missingFavorites.forEach(function (meta) {
-              var cleanPath = normPath(meta.path);
+              // meta.path is the PARENT directory; full path is parent + name
+              var cleanPath = normPath(meta.path + meta.name);
               if (seenPaths[cleanPath]) return;
               seenPaths[cleanPath] = true;
               favoriteItems.push({

--- a/public/js/p3/widget/WorkspaceObjectSelector.js
+++ b/public/js/p3/widget/WorkspaceObjectSelector.js
@@ -339,12 +339,12 @@ define([
       // need to ensure item is in store (for public workspaces),
       // this is more efficient than recursively grabing all public objects of a certain type
       // Also skip adding to store if path contains 'undefined' (invalid user session)
-      // Also skip paths that are too short (e.g., /user/home with no subfolder)
+      // Also skip paths that are too short (e.g., just /user with no workspace)
       if (this.selection !== '*none*' && this.selection && this.selection.path &&
           this.selection.path.indexOf('undefined') === -1) {
-        // Check that path has at least 4 parts (e.g., /user/home/folder)
+        // Check that path has at least 3 parts (e.g., /user/workspace)
         var pathParts = this.selection.path.split('/');
-        if (pathParts.length < 4) {
+        if (pathParts.length < 3) {
           // Path is too high-level, don't add to store
           // But still update the selection state
         } else {
@@ -1324,19 +1324,20 @@ define([
       var label = '<div style="font-size:1em; border-bottom:1px solid grey;">' + starIcon + '/';
       var pathParts = item.path.split('/');
 
-      // Skip items that are too high-level (e.g., /user/home with no subfolder)
-      // These have only 3 parts: ['', 'user', 'home']
-      if (pathParts.length < 4) {
+      // Hide items with fewer than 3 parts (just /user)
+      if (pathParts.length < 3) {
         return '<div style="display:none;"></div>';
       }
 
-      var workspace = pathParts[2]; // home
-      var firstDir = pathParts[3]; // first level under home or file name
+      var workspace = pathParts[2]; // workspace name (e.g., 'home', 'test')
 
-      // Safety check: if firstDir is undefined or empty, hide this item
-      if (!firstDir) {
-        return '<div style="display:none;"></div>';
+      // Top-level workspace (e.g., /user/test) — show workspace name as the label
+      if (pathParts.length === 3) {
+        label += '</br><span style="font-size:1.05em; font-weight:bold;" title="/' + workspace + '">' + workspace + '</span></div>';
+        return label;
       }
+
+      var firstDir = pathParts[3]; // first level under workspace
 
       var title = pathParts.filter(function (p, idx) { return idx > 1 && idx !== (pathParts.length - 1); }).map(function (p) { return p.replace(/^\./, ''); }).join('/');
       var labelParts = [workspace];
@@ -1398,9 +1399,9 @@ define([
             (currentValue.indexOf && currentValue.indexOf('undefined') !== -1)) {
           isValid = false;
         } else {
-          // Check path has enough depth (at least /user/workspace/folder)
+          // Check path has enough depth (at least /user/workspace)
           var pathParts = currentValue.split('/');
-          if (pathParts.length < 4) {
+          if (pathParts.length < 3) {
             isValid = false;
           }
         }


### PR DESCRIPTION
## Summary

- Allow top-level workspaces (e.g. `/user/test`) as valid job output folders — previously rejected by validation, hidden from dropdown, and blocked from store
- Fix cross-workspace favorites using parent directory path instead of full path — `getObjects` returns `meta.path` as the parent directory (`obj[0][2]`), not the full object path, so favorites from other workspaces were stored at wrong paths, causing wrong item selection and most being silently dropped
- Fix duplicate entries in dropdown caused by trailing-slash mismatch between workspace items and favorites lists
- Remove `display:none` CSS hiding of invalid items (caused phantom click targets) in favor of filtering them from the store before population

## Test plan

- [ ] Open any job submission page (e.g. SyntenyGraph)
- [ ] Verify top-level workspaces appear in the output folder dropdown and can be selected
- [ ] Verify all starred folders from other workspaces appear with correct names
- [ ] Verify no duplicate entries in the dropdown
- [ ] Verify selecting a top-level workspace passes form validation and shows the correct name in the textbox
- [ ] Verify selecting a cross-workspace favorite fills in the correct path

🤖 Generated with [Claude Code](https://claude.com/claude-code)