### PR TITLE
Bugfix/collection year facet filter

### DIFF
--- a/public/js/p3/util/QueryToEnglish.js
+++ b/public/js/p3/util/QueryToEnglish.js
@@ -87,13 +87,13 @@ define([
           out = '<span class="searchOperator"> NOT </span>' + walk(term.args[0]);
           break;
         case 'between':
-          out = '<span class="searchField">' + escapeHtml(term.args[0]) + '</span> is between ' + escapeHtml(term.args[1]) + ' and ' + escapeHtml(term.args[2]);
+          out = '<span class="searchField">' + escapeHtml(term.args[0]) + ' </span><span class="searchOperator"> is between </span><span class="searchValue">' + escapeHtml(term.args[1]) + '</span> and <span class="searchValue">' + escapeHtml(term.args[2]) + '</span>';
           break;
         case 'lt':
-          out = '<span class="searchField">' + escapeHtml(term.args[0]) + '</span> &lt;= ' + escapeHtml(term.args[1]);
+          out = '<span class="searchField">' + escapeHtml(term.args[0]) + ' </span><span class="searchOperator"> &lt;= </span><span class="searchValue">' + escapeHtml(term.args[1]) + '</span>';
           break;
         case 'gt':
-          out = '<span class="searchField">' + escapeHtml(term.args[0]) + '</span> &gt;= ' + escapeHtml(term.args[1]);
+          out = '<span class="searchField">' + escapeHtml(term.args[0]) + ' </span><span class="searchOperator"> &gt;= </span><span class="searchValue">' + escapeHtml(term.args[1]) + '</span>';
           break;
         case 'GenomeGroup':
           var groupParts = decodeURIComponent(term.args[0]).split('/');

--- a/public/js/p3/widget/FacetFilter.js
+++ b/public/js/p3/widget/FacetFilter.js
@@ -2,13 +2,13 @@ define([
   'dojo/_base/declare', 'dojo/on', 'dojo/_base/Deferred', 'dijit/_Templated',
   'dojo/dom-class', 'dojo/dom-construct', 'dijit/_WidgetBase', 'dijit/form/TextBox',
   'dojo/_base/xhr', 'dojo/_base/lang', 'dojo/dom-attr', 'dojo/query',
-  'dojo/dom-geometry', 'dojo/dom-style', 'dojo/when', 
+  'dojo/dom-geometry', 'dojo/dom-style', 'dojo/when', 'dojo/debounce',
   '../util/constructMetadataName',
 ], function (
   declare, on, Deferred, Templated,
   domClass, domConstruct, WidgetBase, TextBox,
   xhr, lang, domAttr, Query,
-  domGeometry, domStyle, when,
+  domGeometry, domStyle, when, debounce,
   constructMetadataName
 ) {
 
@@ -246,6 +246,39 @@ define([
       if (filtered && filtered.length > 0) {
         this.set('data', filtered)
       }
+
+      // Compute the pending range filter (mirroring the numeric Advanced Search
+      // fields), but don't push it to the grid yet -- that only happens once
+      // applyRange() runs, i.e. when APPLY is clicked.
+      let filter = '';
+      if (!isNaN(lowerBound) && !isNaN(upperBound)) {
+        filter = 'between(' + this.category + ',' + lowerBound + ',' + upperBound + ')';
+      } else if (!isNaN(lowerBound)) {
+        filter = 'gt(' + this.category + ',' + lowerBound + ')';
+      } else if (!isNaN(upperBound)) {
+        filter = 'lt(' + this.category + ',' + upperBound + ')';
+      }
+
+      this.filter = filter;
+    },
+    applyRange: function () {
+      // Commits the currently-typed min/max range to the grid query. Called
+      // by the APPLY button so the table doesn't refilter on every keystroke.
+      if (this.type !== 'numeric') {
+        return;
+      }
+
+      this.filterByRange()
+
+      domClass.toggle(this.categoryNode, 'selected', !!this.filter);
+
+      on.emit(this.domNode, 'UpdateFilterCategory', {
+        category: this.category,
+        filter: this.filter || '',
+        selected: [],
+        bubbles: true,
+        cancelable: true
+      });
     },
     filterByKeyword: function () {
       if (this.originalData === null) {
@@ -278,8 +311,17 @@ define([
             width: '40px'
           }
         })
-        on(this.facetRangeMin, 'keyup', lang.hitch(this, 'filterByRange'))
-        on(this.facetRangeMax, 'keyup', lang.hitch(this, 'filterByRange'))
+        const debouncedFilterByRange = debounce(lang.hitch(this, 'filterByRange'), 500)
+        const rangeKeyupHandler = function (evt) {
+          // Only queue the filter once the field is empty (cleared) or holds a
+          // full 4-digit year; avoids submitting on incomplete input like "201".
+          const len = evt.target.value.length
+          if (len === 0 || len >= 4) {
+            debouncedFilterByRange()
+          }
+        }
+        on(this.facetRangeMin, 'keyup', rangeKeyupHandler)
+        on(this.facetRangeMax, 'keyup', rangeKeyupHandler)
 
         domConstruct.place(this.facetRangeMin.domNode, this.searchNode, 'last');
         domConstruct.place('<span> to </span>', this.searchNode, 'last');

--- a/public/js/p3/widget/FilterContainerActionBar.js
+++ b/public/js/p3/widget/FilterContainerActionBar.js
@@ -396,6 +396,10 @@ define([
         },
           // callback
           (() => {
+            Object.keys(_self._ffWidgets).forEach(function (cat) {
+              _self._ffWidgets[cat].applyRange()
+            });
+
             if (_self.state && _self.state.hashParams && _self.state.hashParams.filter) {
               on.emit(this.domNode, 'SetAnchor', {
                 bubbles: true,

--- a/public/js/p3/widget/app/templates/Annotation.html
+++ b/public/js/p3/widget/app/templates/Annotation.html
@@ -47,8 +47,8 @@
           <select data-dojo-type="dijit/form/Select" name="recipe" data-dojo-attach-point="recipe" style="width:300px" required="true" data-dojo-attach-event="onChange:onRecipeChange">
             <option value="">--- Select Recipe ---</option>
             <option value="default">Bacteria / Archaea</option>
-            <option value="viral">Viruses - VIGOR4 annotation</option>
-            <option value="viral-lowvan">Viruses - Lowvan annotation</option>
+            <option value="viral">Viruses - VIGOR4 Annotation</option>
+            <option value="viral-lowvan">Viruses - Lowvan Annotation</option>
             <option value="phage">Bacteriophages</option>
           </select>
         </div>


### PR DESCRIPTION
## Summary
The Collection Year facet filter (on genome/taxon "Genomes" tabs) looked functional but didn't actually work — typing a min/max year range narrowed the dropdown list of years shown below the boxes, but never filtered the genome table itself, and the associated "APPLY" button did nothing for this facet. This PR fixes that, adds a couple of UX improvements the fix surfaced, and fixes a related display bug.
## Changes
**`FacetFilter.js`** — the core fix
- `filterByRange()` previously only updated the widget's own displayed value list; it never built a query filter or emitted the event the rest of the app listens for to update the grid. It now builds a real RQL filter (`between(field,lo,hi)`, `gt(field,lo)`, or `lt(field,hi)` depending on which bounds are set), matching the pattern already used elsewhere for the Advanced Search numeric fields.
- Typing is debounced (500ms) and gated on a complete 4-digit year (or an empty field) before a filter is even queued, so a query isn't submitted after every keystroke or on a partial value like "201".
- New `applyRange()` method: commits the currently-typed range to the grid query. The local dropdown list of years still narrows live as you type (unchanged behavior), but the table itself now only refilters once `applyRange()` runs.
**`FilterContainerActionBar.js`**
- The APPLY button now calls `applyRange()` on every facet widget when clicked, so pending Collection Year range edits are committed to the query on click rather than needing to type without pausing. Other facet types (checkboxes, keyword search) are unaffected and continue to filter immediately as before.
**`QueryToEnglish.js`**
- The `between`/`lt`/`gt` breadcrumb rendering never wrapped their values in the `searchValue` span, so range filters didn't get the same orange highlight box as other selected filter values (e.g. `eq`-based selections like a chosen country) in the taxon page breadcrumb. Fixed to match.
## Test plan
- [x] Type a Collection Year range (e.g. 2015–2018) on a genome table's Collection Year facet — dropdown list narrows live, table stays unfiltered until APPLY is clicked.
- [x] Click APPLY — table filters to the matching genomes, breadcrumb shows "COLLECTION_YEAR is between 2015 and 2018" with orange-boxed values.
- [x] Type only a min or only a max value, click APPLY — single-sided range (`>=`/`<=`) filters correctly with orange-boxed value in breadcrumb.
- [x] Verify other facet types (checkboxes like Isolation Country, State Province) still filter immediately on click, unaffected by this change.
- [x] Combine a Collection Year range with another facet selection — both apply together (`AND`), both render with orange boxes in the breadcrumb.