### PR TITLE
Fix query logging across multi-process deployments

### DIFF
--- a/lib/queryLogger.js
+++ b/lib/queryLogger.js
@@ -1,9 +1,6 @@
-var crypto = require('crypto');
 var fs = require('fs');
 var path = require('path');
 var zlib = require('zlib');
-
-var sessions = new Map();
 
 var sessionManager = {
   logDir: null,
@@ -18,60 +15,53 @@ var sessionManager = {
   },
 
   start: function (username) {
-    var sessionId = crypto.randomUUID();
     var ts = new Date().toISOString().replace(/[:.]/g, '-');
     var filename = username + '-' + ts + '.jsonl';
     var filePath = path.join(this.logDir, filename);
-    var writeStream = fs.createWriteStream(filePath, { flags: 'a' });
-
-    writeStream.on('error', function (err) {
-      console.error('queryLogger: write error for ' + filename + ':', err.message);
-    });
-
-    sessions.set(sessionId, {
-      username: username,
-      writeStream: writeStream,
-      filePath: filePath,
-      filename: filename
-    });
-
-    return { sessionId: sessionId, filename: filename };
+    fs.writeFileSync(filePath, '');
+    return { filename: filename };
   },
 
-  stop: function (sessionId) {
-    var session = sessions.get(sessionId);
-    if (session) {
-      session.writeStream.end();
-      sessions.delete(sessionId);
+  isValidFilename: function (filename) {
+    if (!filename) return false;
+    if (filename.indexOf('/') !== -1 || filename.indexOf('\\') !== -1) return false;
+    if (filename.indexOf('..') !== -1) return false;
+    if (!filename.endsWith('.jsonl')) return false;
+    return true;
+  },
+
+  isActive: function (filename) {
+    if (!this.isValidFilename(filename)) return false;
+    try {
+      fs.accessSync(path.join(this.logDir, filename), fs.constants.W_OK);
       return true;
+    } catch (e) {
+      return false;
     }
-    return false;
-  },
-
-  getSession: function (sessionId) {
-    return sessions.get(sessionId) || null;
   }
 };
 
-function writeEntry(sessionId, entry) {
+function appendEntry(filePath, entry) {
   var line = JSON.stringify(entry) + '\n';
-  var currentSession = sessions.get(sessionId);
-  if (currentSession && currentSession.writeStream.writable) {
-    currentSession.writeStream.write(line);
-  }
+  fs.appendFile(filePath, line, function (err) {
+    if (err) {
+      console.error('queryLogger: write error for ' + filePath + ':', err.message);
+    }
+  });
 }
 
 function middleware() {
   return function queryLogMiddleware(req, res, next) {
-    var sessionId = req.cookies && req.cookies._querylog;
-    if (!sessionId) {
+    var filename = req.cookies && req.cookies._querylog;
+    if (!filename) {
       return next();
     }
 
-    var session = sessions.get(sessionId);
-    if (!session) {
+    if (!sessionManager.isValidFilename(filename) || !sessionManager.logDir) {
       return next();
     }
+
+    var filePath = path.join(sessionManager.logDir, filename);
 
     var startTime = Date.now();
     var entry = {
@@ -124,7 +114,7 @@ function middleware() {
 
       if (isDownload) {
         entry.download = true;
-        writeEntry(sessionId, entry);
+        appendEntry(filePath, entry);
       } else {
         var raw = Buffer.concat(chunks);
         entry.responseTruncated = totalSize > maxSize;
@@ -139,11 +129,11 @@ function middleware() {
             } else {
               entry.response = decoded.toString('utf-8');
             }
-            writeEntry(sessionId, entry);
+            appendEntry(filePath, entry);
           });
         } else {
           entry.response = raw.toString('utf-8');
-          writeEntry(sessionId, entry);
+          appendEntry(filePath, entry);
         }
       }
     });

--- a/routes/queryLog.js
+++ b/routes/queryLog.js
@@ -28,7 +28,7 @@ module.exports = function (sessionManager) {
     }
 
     var result = sessionManager.start(username);
-    res.cookie('_querylog', result.sessionId, {
+    res.cookie('_querylog', result.filename, {
       path: '/',
       httpOnly: true,
       sameSite: 'lax'
@@ -37,29 +37,18 @@ module.exports = function (sessionManager) {
   });
 
   router.post('/stop', function (req, res) {
-    var sessionId = req.cookies && req.cookies._querylog;
-    if (!sessionId) {
-      return res.json({ status: 'not_active' });
-    }
-
-    sessionManager.stop(sessionId);
     res.clearCookie('_querylog', { path: '/' });
     res.json({ status: 'stopped' });
   });
 
   router.get('/status', function (req, res) {
-    var sessionId = req.cookies && req.cookies._querylog;
-    if (!sessionId) {
-      return res.json({ active: false });
-    }
-
-    var session = sessionManager.getSession(sessionId);
-    if (!session) {
+    var filename = req.cookies && req.cookies._querylog;
+    if (!filename || !sessionManager.isActive(filename)) {
       res.clearCookie('_querylog', { path: '/' });
       return res.json({ active: false });
     }
 
-    res.json({ active: true, filename: session.filename });
+    res.json({ active: true, filename: filename });
   });
 
   return router;


### PR DESCRIPTION
## Summary
- Replace in-memory session Map with filesystem-based approach so query logging works across all Node.js worker processes
- Cookie now stores the log filename directly; each process appends entries via fs.appendFile instead of requiring a shared writeStream
- Adds filename validation to prevent path traversal

## Context
Follow-up to #1361. On production (which runs multiple Node.js processes), logging only worked for requests that happened to hit the same worker that started the session. This fix eliminates the per-process state so all workers can write to the same log file.

## Test plan
- [ ] Start query logging from User Profile
- [ ] Browse multiple pages, including opening new browser tabs
- [ ] Verify all tabs API requests appear in the log file
- [ ] Run replay script against the log to confirm format is unchanged