### PR TITLE
Use eq(genome_id,*) base clause for GenomeList selection queries

### DIFF
--- a/public/js/p3/widget/DataItemFormatter.js
+++ b/public/js/p3/widget/DataItemFormatter.js
@@ -2194,7 +2194,7 @@ define([
         text: 'genome_ids',
         link: function (obj) {
           if (obj.genome_ids.length > 1) {
-            return `<a href="/view/GenomeList/?eq(*,*)&genome(in(genome_id,(${obj.genome_ids.join(',')})))">${obj.genome_ids}</a>`;
+            return `<a href="/view/GenomeList/?eq(genome_id,*)&genome(in(genome_id,(${obj.genome_ids.join(',')})))">${obj.genome_ids}</a>`;
           } else if (obj.genome_ids.length == 1) {
             return `<a href="/view/Genome/${obj.genome_ids[0]}">${obj.genome_ids[0]}</a>`;
           }

--- a/public/js/p3/widget/GridContainer.js
+++ b/public/js/p3/widget/GridContainer.js
@@ -952,7 +952,7 @@ define([
             popup.open({
               popup: new PerspectiveToolTipDialog({
                 perspective: 'GenomeList',
-                perspectiveUrl: '/view/GenomeList/?eq(*,*)&genome(in(genome_id,(' + genome_ids.join(',') + ')))'
+                perspectiveUrl: '/view/GenomeList/?eq(genome_id,*)&genome(in(genome_id,(' + genome_ids.join(',') + ')))'
               }),
               around: button,
               orient: ['below']
@@ -961,7 +961,7 @@ define([
         },
         function (selection) {
           const genome_ids = Array.from(selection.reduce((p, v) => { return p.add(v.genome_id) }, new Set()))
-          Topic.publish('/navigate', { href: '/view/GenomeList/?eq(*,*)&genome(in(genome_id,(' + genome_ids.join(',') + ')))' });
+          Topic.publish('/navigate', { href: '/view/GenomeList/?eq(genome_id,*)&genome(in(genome_id,(' + genome_ids.join(',') + ')))' });
         },
         false
       ],

--- a/public/js/p3/widget/StrainGridContainer.js
+++ b/public/js/p3/widget/StrainGridContainer.js
@@ -114,7 +114,7 @@ define([
             popup.open({
               popup: new PerspectiveToolTipDialog({
                 perspective: 'GenomeList',
-                perspectiveUrl: '/view/GenomeList/?eq(*,*)&genome(in(genome_id,(' + genome_ids.join(',') + ')))'
+                perspectiveUrl: '/view/GenomeList/?eq(genome_id,*)&genome(in(genome_id,(' + genome_ids.join(',') + ')))'
               }),
               around: button,
               orient: ['below']
@@ -123,7 +123,7 @@ define([
         },
         function (selection) {
           const genome_ids = Array.from(selection.reduce((p, v) => { return p.add(v.genome_ids) }, new Set()))
-          Topic.publish('/navigate', { href: '/view/GenomeList/?eq(*,*)&genome(in(genome_id,(' + genome_ids.join(',') + ')))' });
+          Topic.publish('/navigate', { href: '/view/GenomeList/?eq(genome_id,*)&genome(in(genome_id,(' + genome_ids.join(',') + ')))' });
         },
         false
       ], [

--- a/public/js/p3/widget/StrainGridContainer_Bunyavirales.js
+++ b/public/js/p3/widget/StrainGridContainer_Bunyavirales.js
@@ -114,7 +114,7 @@ define([
             popup.open({
               popup: new PerspectiveToolTipDialog({
                 perspective: 'GenomeList',
-                perspectiveUrl: '/view/GenomeList/?eq(*,*)&genome(in(genome_id,(' + genome_ids.join(',') + ')))'
+                perspectiveUrl: '/view/GenomeList/?eq(genome_id,*)&genome(in(genome_id,(' + genome_ids.join(',') + ')))'
               }),
               around: button,
               orient: ['below']
@@ -123,7 +123,7 @@ define([
         },
         function (selection) {
           const genome_ids = Array.from(selection.reduce((p, v) => { return p.add(v.genome_ids) }, new Set()))
-          Topic.publish('/navigate', { href: '/view/GenomeList/?eq(*,*)&genome(in(genome_id,(' + genome_ids.join(',') + ')))' });
+          Topic.publish('/navigate', { href: '/view/GenomeList/?eq(genome_id,*)&genome(in(genome_id,(' + genome_ids.join(',') + ')))' });
         },
         false
       ], [

--- a/public/js/p3/widget/StrainGridContainer_Orthomyxoviridae.js
+++ b/public/js/p3/widget/StrainGridContainer_Orthomyxoviridae.js
@@ -114,7 +114,7 @@ define([
             popup.open({
               popup: new PerspectiveToolTipDialog({
                 perspective: 'GenomeList',
-                perspectiveUrl: '/view/GenomeList/?eq(*,*)&genome(in(genome_id,(' + genome_ids.join(',') + ')))'
+                perspectiveUrl: '/view/GenomeList/?eq(genome_id,*)&genome(in(genome_id,(' + genome_ids.join(',') + ')))'
               }),
               around: button,
               orient: ['below']
@@ -123,7 +123,7 @@ define([
         },
         function (selection) {
           const genome_ids = Array.from(selection.reduce((p, v) => { return p.add(v.genome_ids) }, new Set()))
-          Topic.publish('/navigate', { href: '/view/GenomeList/?eq(*,*)&genome(in(genome_id,(' + genome_ids.join(',') + ')))' });
+          Topic.publish('/navigate', { href: '/view/GenomeList/?eq(genome_id,*)&genome(in(genome_id,(' + genome_ids.join(',') + ')))' });
         },
         false
       ], [


### PR DESCRIPTION
## Summary

The **GENOMES** action-bar button (and the serology genome-id links in `DataItemFormatter`) build GenomeList URLs with a malformed base clause:

```
/view/GenomeList/?eq(*,*)&genome(in(genome_id,(...)))
```

The `genome(...)` part is a cross-core **join** filter that requires a primary match clause in front of it. `eq(*,*)` uses a wildcard *field name*, which is inconsistent with the canonical idiom used everywhere else in the codebase (`GenomeSearch.js`, `Host.js`, `Taxonomy.js`, `buildGlobalSearchQuery.js`):

```
eq(genome_id,*)&genome(<join>)
```

This PR replaces `eq(*,*)` with `eq(genome_id,*)` at all 9 sites so the emitted query matches the established pattern.

## Changes (9 sites, 5 files)

- `public/js/p3/widget/GridContainer.js` — pressAndHold popup + click handler
- `public/js/p3/widget/StrainGridContainer.js`
- `public/js/p3/widget/StrainGridContainer_Bunyavirales.js`
- `public/js/p3/widget/StrainGridContainer_Orthomyxoviridae.js`
- `public/js/p3/widget/DataItemFormatter.js` — serology "Genome IDs" link

## Verification

Tested against the live Data API with the genome IDs from the original report:

- `eq(genome_id,*)&genome(in(genome_id,(...)))` → **HTTP 200**, returns exactly the selected genomes (verified on both `genome` and `genome_feature` cores).
- The old `eq(*,*)` form also returned 200 — so this is a **consistency cleanup**, not a fix for a user-visible failure in the shipped code.
- Removing the base clause entirely (`genome(in(...))` alone) reproduces the Solr `Cannot parse '()'` 400 error, confirming the base clause is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)