### PR TITLE
fix(homology): empty BLAST result grid — encode workspace path + guard API truncation (JIRA-4420)

### DIFF
--- a/public/js/p3/store/HomologyResultMemoryStore.js
+++ b/public/js/p3/store/HomologyResultMemoryStore.js
@@ -193,7 +193,12 @@ define([
               res.lookups.push(this.getBlankMeta(resultIds));
             }
 
-            var query = { rows: 25000 };
+            // The data API silently truncates its response when rows >= 10000
+            // (returns HTTP 200 with a truncated body, which then fails JSON parsing).
+            // The decoration query only needs one Solr doc per BLAST hit id, so bound
+            // rows by the id count, capped safely below the API ceiling. See JIRA-4420.
+            var MAX_DECORATION_ROWS = 9000;
+            var query = { rows: Math.min(resultIds.length || 1, MAX_DECORATION_ROWS) };
 
             // var doQuery = false;
             if (this.type == 'genome_sequence') {
@@ -301,6 +306,14 @@ define([
                   }
                 }, this);
                 res.lookups.push(keyMap);
+                this.defaultLoadData(res);
+              }), lang.hitch(this, function (err) {
+                // Decoration query failed (e.g. API returned a truncated body).
+                // Don't leave the grid hanging on an unresolved deferred: render the
+                // BLAST results without Solr metadata rather than showing nothing.
+                console.warn('HomologyResultMemoryStore: decoration query failed, '
+                  + 'rendering results without metadata:', err);
+                res.lookups.push({});
                 this.defaultLoadData(res);
               }));
             }

--- a/public/js/p3/widget/WorkspaceBrowser.js
+++ b/public/js/p3/widget/WorkspaceBrowser.js
@@ -830,7 +830,7 @@ define([
       }, function (selection) {
         // console.log("Current Container Widget: ", self.actionPanel.currentContainerWidget, "Slection: ", selection)
         var modPath = self.actionPanel.currentContainerWidget.path.replace(/^\/public/, '');
-        Topic.publish('/navigate', { href: '/view/Homology' + modPath });
+        Topic.publish('/navigate', { href: '/view/Homology' + encodePath(modPath) });
       }, false);
 
 


### PR DESCRIPTION
## Summary

Fixes **JIRA-4420**: the BLAST/Homology job result view renders an empty grid for certain jobs, even though the underlying data files open fine.

Two independent defects were found, both of which had to be fixed for the reported cases to work. Both surface with the identical symptom: clicking **VIEW** shows no data, while clicking the individual data files in the folder works.

Reported cases (MarielaS workspace):
- `.../home/Clostridium/Clostridium #50 BALST` — the ticket's original case (`#` in the folder name).
- `.../home/Staphylococcus/S.pseudi_2023/blast_2006_2` — surfaced the second defect during investigation.

---

## Bug 1 — `#` in folder name breaks Homology VIEW navigation (the ticket's case)

**Root cause:** The Homology **VIEW** action in `WorkspaceBrowser.js` built its navigation href from the **raw, unencoded** workspace path:

```js
var modPath = self.actionPanel.currentContainerWidget.path.replace(/^\/public/, '');
Topic.publish('/navigate', { href: '/view/Homology' + modPath });
```

For a job folder named `Clostridium #50 BALST`, the literal `#` is treated as a URL **fragment delimiter**. The router truncated the path — `window.location.pathname` ended at `.../Clostridium%20`, and `#50 BALST` leaked into `location.hash`. The store therefore received a wrong/nonexistent `dataPath` (`/…/Clostridium ` — everything after the `#` gone), the workspace fetch failed, and the grid hung empty.

Every other VIEW action in `WorkspaceBrowser.js` wraps the path in `encodePath(...)` (which `encodeURIComponent`s each segment: `#`→`%23`, space→`%20`) — the Homology one was the lone exception. `encodePath` produces exactly the encoding the folder URL already uses and that the store's `_setState` decodes back.

**Fix:**
```js
Topic.publish('/navigate', { href: '/view/Homology' + encodePath(modPath) });
```

**Verified live:** clicking VIEW on the `Clostridium #50 BALST` job now navigates to `.../Clostridium%20%2350%20BALST` (no stray `#` fragment), the store's `dataPath` is correct, and the grid renders **1 – 200 of 1588 results**.

---

## Bug 2 — silent API response truncation on the result decoration query

**Root cause:** Once the path is correct, the store loads `HomologyResultMemoryStore`. Because `db_type = fna`/`faa`, it issues a Solr **decoration query** to `/<dataAPI>/genome_sequence/` (or `genome_feature/`) to attach genome/accession metadata to each BLAST hit. That query was sent with a **hardcoded `rows: 25000`**.

The data API **silently truncates its response when `rows >= 10000`** — it returns **HTTP 200 with a truncated body** (literally a single `[`), which then fails JSON parsing with `Unexpected end of JSON input`. The decoration `request.post` had **no error handler**, so the rejected promise was swallowed: `this._loadingDeferred` never resolved and the grid hung empty, with only `_loadingDeferred already exists, load in progress` in the console and no error. (This is why the symptom first looked like a "quoting" issue too.)

### Bisected trigger (reproduced live against the deployment's API)

| `rows` | result |
|-------:|--------|
| 5000   | 184 KB, valid JSON |
| 9999   | 610 KB, valid JSON |
| **10000** | `[` (truncated, HTTP 200) |
| 25000  | `[` (truncated, HTTP 200) |

The break is at **exactly `rows >= 10000`**, reproducible even with `q=*:*`, on both `genome_sequence` and `genome_feature`. Quoted vs. unquoted `accession:(...)` behave identically — confirming this half is **not** a quoting problem.

**Fix (in `HomologyResultMemoryStore.js`):**
1. **Bound `rows` by the BLAST hit-id count**, capped at 9000 (safely below the API's 10000-row truncation ceiling). The decoration only needs one Solr doc per hit, so 25000 was never meaningful.
2. **Add an error handler** to the decoration query so a failed/truncated response still resolves the load and renders results *without* Solr metadata, instead of hanging on an empty grid.

**Verified live:** the `blast_2006_2` job renders **30 / 30 results**. (Genome/Description columns are empty for that job because the subjects are private-assembly contigs not in Solr — the decoration correctly returns 0 matches and results render via the graceful-degradation path.) The larger `Clostridium #50 BALST` job (29 MB `blast_out.json`, 1588 hits) also loads cleanly through the capped path.

---

## ⚠️ API-side truncation bug (for the data API team)

The client-side cap fixes the reported symptom, but the underlying defect in Bug 2 is **server-side** and worth its own ticket. **Please forward this section to whoever owns the data API.**

- **Symptom:** a query with `rows >= 10000` returns **HTTP 200 with a truncated response body** (a bare `[`) instead of complete JSON or an error status.
- **Boundary:** the cutoff is **exactly `rows >= 10000`** — the classic Solr deep-paging / `maxRows` guard. `rows: 9999` returns complete valid JSON; `rows: 10000` returns `[`.
- **Reproducible with a trivial query:** `POST /<dataAPI>/genome_sequence/` with `q=*:*`, `fl=sequence_id`, `rows=10000` → one-byte `[` body, status 200. Same on `genome_feature`. Independent of the query terms/quoting.
- **Why it's dangerous:** returning **200 + truncated body** (rather than a 4xx/5xx, or a complete-but-capped result set) silently corrupts every client that requests large `rows`. It masks the failure as a client-side JSON parse error, far from the real cause.
- **Note:** this was believed to be fixed in a recent data API change. Whatever that fix was, it is **not effective on the deployment behind this site's `/api` path** — the `rows >= 10000` truncation still reproduces there.
- **Requested behavior:** either (a) stream/return the full result set for large `rows`, or (b) if a hard cap is intended, return an explicit error status (or a well-formed, documented capped response) — never HTTP 200 with a truncated/invalid body.

---

## Scope / follow-up

- **Other quoting sites:** the raw-path-in-href pattern behind Bug 1 exists at a few other `/navigate` calls in `WorkspaceBrowser.js` (e.g. `/view/MSA/`, the `afa_file` MSA links, and a couple of `/workspace`/`/view/Gexf` links). They would break the same way on a `#`/space folder name. A dedicated pass over the codebase for quoting/encoding issues is planned separately.
- **Other large-`rows` sites:** `rows: 25000` is copy-pasted across ~9 other result stores (`BlastResultMemoryStore`, `ProteinFamiliesService*`, `IDMapping`, `GenomeDistanceResult`, `CorrelatedGenes`, `PathwaySummary`, …). Any that legitimately returns ≥10k rows will hit the identical silent truncation. Left out of this PR; may be moot once the API-side bug is fixed.

## Commits

- `encode workspace path in Homology VIEW navigation` — Bug 1 (`WorkspaceBrowser.js`)
- `avoid silent API truncation on BLAST result decoration` — Bug 2 (`HomologyResultMemoryStore.js`)

## Test plan

- [x] Reproduced both empty-grid cases live (as MarielaS).
- [x] Bug 1: confirmed the `#` folder truncates the path pre-fix; confirmed the VIEW button renders 1588 results post-fix.
- [x] Bug 2: bisected the truncation boundary to `rows >= 10000` against the live API; confirmed 30/30 results post-fix.
- [x] ESLint: no new errors introduced on changed lines (pre-existing errors in both files are unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
