### PR TITLE
fix(workspace): encode remaining VIEW/navigation path producers (follow-up to #1159/#1161)

### DIFF
--- a/public/js/p3/widget/GroupExplore.js
+++ b/public/js/p3/widget/GroupExplore.js
@@ -3,13 +3,15 @@ define([
   'dojo/dom-class', 'dijit/layout/ContentPane', 'dojo/dom-construct',
   'dojo/_base/Deferred',
   'dojo/request', 'dojo/_base/lang', 'dojo/when', '../WorkspaceManager',
-  'd3/d3', './Venn', 'dgrid/Grid', 'dgrid/extensions/ColumnResizer'
+  'd3/d3', './Venn', 'dgrid/Grid', 'dgrid/extensions/ColumnResizer',
+  '../util/encodePath'
 ], function (
   declare, WidgetBase, on, Topic,
   domClass, ContentPane, domConstruct,
   fDeferred,
   xhr, lang, when, WorkspaceManager,
-  d3, Venn, Grid, ColumnResizer
+  d3, Venn, Grid, ColumnResizer,
+  encodePath
 ) {
 
   var groupCompare = null;
@@ -292,7 +294,11 @@ define([
       console.log('ids=', id_array);
       console.log('myPath=', myPath);
       WorkspaceManager.createGroup(regionGroupName, myType, myPath, idType, id_array);
-      document.getElementById('create_msg').innerHTML = "<b>The group has been successfully created. Click <a href='/workspace" + myPath + '/' + regionGroupName + "' target=_blank>here</a> to view.</b>";
+      // encodePath the full workspace path so special characters (spaces, #, ', etc.)
+      // in the folder path or the user-supplied group name neither break the URL nor
+      // inject markup into this innerHTML string. See path-encoding pass / JIRA-4420.
+      var groupHref = '/workspace' + encodePath(myPath.replace(/\/+$/, '') + '/' + regionGroupName);
+      document.getElementById('create_msg').innerHTML = "<b>The group has been successfully created. Click <a href='" + groupHref + "' target=_blank>here</a> to view.</b>";
       document.getElementById('create_msg').style = 'color: green';
       // alert("Please refresh the workspace folder to view.");
     } else if (regionGroupName) {

--- a/public/js/p3/widget/WorkspaceBrowser.js
+++ b/public/js/p3/widget/WorkspaceBrowser.js
@@ -1536,9 +1536,9 @@ define([
               alignType = 'dna';
             }
             if (exist_nwk == 1) {
-              Topic.publish('/navigate', { href: '/view/MSATree/&alignType=' + alignType + '&path=' + afa_file, target: 'blank' });
+              Topic.publish('/navigate', { href: '/view/MSATree/&alignType=' + alignType + '&path=' + encodeURIComponent(afa_file), target: 'blank' });
             } else {
-              Topic.publish('/navigate', { href: '/view/MSAView/&alignType=' + alignType + '&path=' + afa_file, target: 'blank' });
+              Topic.publish('/navigate', { href: '/view/MSAView/&alignType=' + alignType + '&path=' + encodeURIComponent(afa_file), target: 'blank' });
             }
           });
         }
@@ -2055,7 +2055,7 @@ define([
         var item = selection[0];
         var parentPath = item.path.split('/').slice(0, -1).join('/');
         if (parentPath) {
-          Topic.publish('/navigate', { href: '/workspace' + parentPath, target: 'blank' });
+          Topic.publish('/navigate', { href: '/workspace' + encodePath(parentPath), target: 'blank' });
         }
       }, true); // The 'enabled' flag should be true so it can be controlled by logic
 
@@ -2781,7 +2781,7 @@ define([
             }
             break;
           case 'gexf':
-            Topic.publish('/navigate', { href: '/view/Gexf' + '&path=' + this.file, target: 'blank' });
+            Topic.publish('/navigate', { href: '/view/Gexf' + '&path=' + encodeURIComponent(this.file), target: 'blank' });
             return;
           case 'genome_group':
             panelCtor = window.App.getConstructor('p3/widget/viewer/WSGenomeGroup');


### PR DESCRIPTION
## Summary

Completes the workspace-path encoding work started in **#1159 / #1161**. Those PRs fixed the **decode (consumer)** side — every viewer's `_setStateAttr`/`onSetState` now `decodeURIComponent`s each path segment. They did **not** audit the **encode (producer)** side that *builds* the `/view` and `/workspace` hrefs. This PR closes that gap for the four remaining raw-path producers.

### Why the decode-side fixes weren't enough

The #1159/#1161 fixes assume the incoming `state.pathname` is already correctly percent-encoded and just needs decoding. That works for spaces (`%20` survives the round-trip). It **cannot** work for `#`: a raw `#` in an href is consumed by the browser as the **fragment delimiter** and truncates `location.pathname` *before* any viewer sees it. The only place to prevent that is at the producer — the same root cause as JIRA-4420's Homology VIEW (fixed separately in #1379).

## Changes

| File / site | Before | Fix |
|---|---|---|
| `WorkspaceBrowser.js` — View-AFA MSATree/MSAView (`afa_file`) | raw path | `encodeURIComponent(afa_file)` — matches the sibling MSA action a few lines up that already encoded |
| `WorkspaceBrowser.js` — Gexf viewer (`this.file`) | raw path | `encodeURIComponent(this.file)` — consumer decodes via `URLSearchParams`; sibling Gexf producer already used `encodePath` |
| `WorkspaceBrowser.js` — "Open parent folder" search action (`parentPath`) | raw path | `encodePath(parentPath)` — the lone `/workspace` nav in the file not already using `encodePath` |
| `GroupExplore.js` — created-group success link | raw `myPath` + user-typed group name in `innerHTML` href | build full path and `encodePath` it — fixes both the URL breakage **and** the unescaped-`innerHTML` injection vector (the group name is user input) |

`encodePath` / `encodeURIComponent` produce exactly the encoding the workspace URLs already use and that the viewers' decode-side logic (from #1159/#1161) round-trips back.

## Verified safe — intentionally NOT changed

- **`/view/<Type>/<id>` links** (`GridContainer.js`, `FeatureOverview.js`, `IDMapping*`, …) — interpolate numeric/opaque IDs, not workspace paths.
- **Search `keyword()` queries** (`public/js/p3/widget/search/*.js`) — uniformly wrapped in `TextInputEncoder(sanitizeInput(...))`.
- **Breadcrumb `innerHTML`** via `QueryToEnglish` — still escaped by `escapeHtml` (from #1133, intact).
- **All other `WorkspaceBrowser.js` VIEW actions** (Homology, Pathway/ProteinFamilies/Subsystem services, GenomeGroup/FeatureGroup, GenomeAlignment, Phylo trees) — already use `encodePath`.
- **Dead code:** the `/view/MSA/` click handler at the top of `WorkspaceBrowser.js` reads `viewMSATT.selection`, which is never assigned, and no action opens that dialog. Left as-is (its URL tail is a feature-id query string, not a path, anyway).

## Test plan

- [x] Audited all `/navigate` and `innerHTML`-href producers in `public/js/p3` against the three prior escaping PRs.
- [x] Each fix matched against an already-correct sibling producer + confirmed consumer decode round-trips.
- [x] ESLint: no new errors on changed lines (all reported errors are pre-existing file-wide indent/strict/no-useless-concat).

## Related

- #1159, #1161 — decode-side path escaping (this is the producer-side follow-up).
- #1133 — `QueryToEnglish` XSS escaping (still intact).
- #1379 — Homology VIEW producer fix (JIRA-4420); same root cause, separate branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
