### PR TITLE
chore(deps): bump nodemailer 7 → 9 (security)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "morgan": "^1.11.0",
         "MultiBigWig": "github:BV-BRC/multibigwig#master",
         "nconf": "^0.12.1",
-        "nodemailer": "^7.0.11",
+        "nodemailer": "^9.0.1",
         "phyloxml": "^1.0.0",
         "promised-io": "^0.3.6",
         "pug": "^3.0.3",
@@ -65,6 +65,9 @@
         "minimatch": "^9.0.9",
         "stylelint": "^16.5.0",
         "stylelint-config-standard": "^36.0.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -13372,9 +13375,9 @@
       "license": "MIT"
     },
     "node_modules/nodemailer": {
-      "version": "7.0.12",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.12.tgz",
-      "integrity": "sha512-H+rnK5bX2Pi/6ms3sN4/jRQvYSMltV6vqup/0SFOrxYYY/qoNvhXPlYq3e+Pm9RFJRwrMGbMIwi81M4dxpomhA==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.5.tgz",
+      "integrity": "sha512-wvjiKvjczmsN7U/8006JOdXubgBk2XFAbioDMbT+sM7cPs0QrhJTa6KBRX7P5REGGkDcLUz/EarWidb8G8C1jQ==",
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "morgan": "^1.11.0",
     "MultiBigWig": "github:BV-BRC/multibigwig#master",
     "nconf": "^0.12.1",
-    "nodemailer": "^7.0.11",
+    "nodemailer": "^9.0.1",
     "phyloxml": "^1.0.0",
     "promised-io": "^0.3.6",
     "pug": "^3.0.3",


### PR DESCRIPTION
Bumps **nodemailer** `^7.0.11` → `^9.0.1` (lockfile resolves 9.0.5). Supersedes dependabot #1344, which targets `master`.

## Why
`npm audit` flags **6 advisories** on nodemailer `<=9.0.0`, all fixed only above 9.0.0:

| Advisory | Sev |
|---|---|
| [GHSA-c7w3-x93f-qmm8](https://github.com/advisories/GHSA-c7w3-x93f-qmm8) — SMTP command injection via `envelope.size` | high |
| [GHSA-vvjj-xcjg-gr5g](https://github.com/advisories/GHSA-vvjj-xcjg-gr5g) — SMTP command injection via CRLF in transport `name` (EHLO/HELO) | |
| [GHSA-268h-hp4c-crq3](https://github.com/advisories/GHSA-268h-hp4c-crq3) — CRLF injection in `List-*` header comments | |
| [GHSA-wqvq-jvpq-h66f](https://github.com/advisories/GHSA-wqvq-jvpq-h66f) — `jsonTransport` bypasses `disableFileAccess`/`disableUrlAccess` | |
| [GHSA-r7g4-qg5f-qqm2](https://github.com/advisories/GHSA-r7g4-qg5f-qqm2) — improper TLS cert validation in OAuth2 token fetch | |
| [GHSA-p6gq-j5cr-w38f](https://github.com/advisories/GHSA-p6gq-j5cr-w38f) — `raw` option bypasses file/URL access → file read + SSRF | |

Floor set to `^9.0.1` because 9.0.0 is itself in the vulnerable range.

## Compatibility — reviewed, no code change needed
Consumers: `routes/reportProblem.js`, `routes/notifySubmitSequence.js`. Both use only `createTransport(opts)` + callback `transport.sendMail(msg, cb)` — unchanged in v9.

- **Pure CommonJS**, `engines: >=6`, no ESM-only transitive → no repeat of the sanitize-html/htmlparser2 prod-Node-22 crash.
- The v9 **breaking change** — TLS cert validation now enforced when fetching **remote** attachment content (href/path URLs), OAuth2 token endpoints, and proxy CONNECT — **does not apply here**: attachments stream from local disk (`fs.createReadStream`), no OAuth2, no HTTP proxy. SMTP-connection TLS already sets `rejectUnauthorized: true` explicitly in both routes.

## Verification
- Lockfile regenerated; `npm audit` no longer lists nodemailer.
- `createTransport(...).sendMail` present on 9.0.5.
- `node -e "require('./app.js')"` smoke test passes with 9.0.5 installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)