### PR TITLE
fix(reportProblem): repair broken email attachments (formidable v2 property names)

### DIFF
--- a/routes/reportProblem.js
+++ b/routes/reportProblem.js
@@ -46,9 +46,14 @@ function mail(message, subject, from, files, options) {
   var attachments = [];
   if (files && files.length > 0) {
     files.forEach(function (f) {
+      // formidable v2+ renamed the parsed-file properties: name->originalFilename,
+      // path->filepath (the v1 names are undefined under the installed v2, which
+      // silently broke attachments -> fs.createReadStream(undefined)). Read the
+      // v2 names, falling back to v1 so this works regardless of which formidable
+      // version express-formidable resolves.
       var attach = {};
-      attach.filename = f.name;
-      attach.content = fs.createReadStream(f.path);
+      attach.filename = f.originalFilename || f.name;
+      attach.content = fs.createReadStream(f.filepath || f.path);
       attachments.push(attach);
     });
     mailmsg.attachments = attachments;


### PR DESCRIPTION
## Problem
Problem-report email **attachments have been silently broken**. The attachment builder in `routes/reportProblem.js` reads formidable **v1** property names:

```js
attach.filename = f.name;                       // undefined under formidable v2
attach.content  = fs.createReadStream(f.path);   // undefined -> createReadStream(undefined)
```

But the installed formidable is **v2.x** (pulled in via `express-formidable`), which renamed the parsed-file properties: `name` → `originalFilename`, `path` → `filepath`. Under v2, `f.name`/`f.path` are `undefined`, so the attachment gets no filename and `fs.createReadStream(undefined)` fails. The report email's **text body still sends**, but any **attached file is dropped/errors** — so the breakage is easy to miss.

Verified empirically: parsing a multipart upload with the installed formidable 2.1.5 yields `f.name === undefined` and `f.path === undefined` (real values live on `f.originalFilename` / `f.filepath`).

## Fix
Read the v2 names, falling back to the v1 names, so it works regardless of which formidable version `express-formidable` resolves:

```js
attach.filename = f.originalFilename || f.name;
attach.content  = fs.createReadStream(f.filepath || f.path);
```

## Verification
End-to-end test: a real `multipart/form-data` POST driven through the actual `express-formidable` middleware, then through the fixed attachment builder →
- `attach.filename` = `hello.txt`
- `attach.content` is a ReadStream that yields the correct bytes (`HELLO`)

## Context
Found while evaluating dependabot's formidable 2→3 bump (#970, closed). This is a pre-existing bug independent of that bump — the code was written against formidable v1 and never updated when the dep moved to v2. Scoped to a single file, no dependency change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)