### PR TITLE
ci: enable npm test step (test script repaired in #1387)

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -42,8 +42,5 @@ jobs:
       - name: Smoke test — server module graph loads (catches require/ESM breakage)
         run: node -e "require('./app.js'); console.log('server module graph loaded OK')"
 
-      # Unit tests are enabled once the test-script repair (PR #1387) lands on
-      # these branches; until then `npm test` still points at the dead gulp
-      # pipeline. Uncomment when available:
-      # - name: Unit tests
-      #   run: npm test
+      - name: Unit tests
+        run: npm test


### PR DESCRIPTION
Now that #1387 (merged) repaired `npm test` to run the real jest suite, enable the previously-commented-out **Unit tests** step in CI.

The step runs `npm test` on the Node 22.x matrix for push/PR to `alpha`/`beta`/`master`, alongside the existing module-load smoke test.

Verified on current `alpha` HEAD: `npm ci && npm test` → **6 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)