### PR TITLE
PredictStructure: remove AlphaFold 2 from the tool selector

### DIFF
--- a/public/js/p3/widget/app/PredictStructure.js
+++ b/public/js/p3/widget/app/PredictStructure.js
@@ -16,7 +16,7 @@ define([
     applicationName: 'PredictStructure',
     requireAuth: true,
     applicationLabel: 'Protein Structure Prediction',
-    applicationDescription: 'Predict biomolecular structures (proteins, complexes, protein-DNA/RNA, protein-ligand) using Boltz, OpenFold 3, Chai, AlphaFold 2, or ESMFold. Provides a unified interface with automatic parameter mapping, format conversion, output normalization, and confidence scoring.',
+    applicationDescription: 'Predict biomolecular structures (proteins, complexes, protein-DNA/RNA, protein-ligand) using Boltz, OpenFold 3, Chai, or ESMFold. Provides a unified interface with automatic parameter mapping, format conversion, output normalization, and confidence scoring.',
     applicationHelp: 'quick_references/services/predict_structure_service.html',
     tutorialLink: 'tutorial/predict_structure/predict_structure.html',
     videoLink: '',
@@ -80,8 +80,6 @@ define([
       var msg;
       if (tool === 'esmfold') {
         msg = 'ESMFold does not use an MSA; this section is ignored.';
-      } else if (tool === 'alphafold') {
-        msg = 'AlphaFold 2 builds its own MSA from BV-BRC databases; this section is ignored.';
       } else if (tool === 'boltz' || tool === 'openfold' || tool === 'chai') {
         msg = 'Required for the selected prediction tool. Choose <i>Precomputed MSA from Workspace</i> to upload one, or <i>Use MSA Server or Service</i> to have BV-BRC compute one with ColabFold.';
       } else {

--- a/public/js/p3/widget/app/templates/PredictStructure.html
+++ b/public/js/p3/widget/app/templates/PredictStructure.html
@@ -39,7 +39,6 @@
               <option value="boltz">Boltz-2</option>
               <option value="openfold">OpenFold 3</option>
               <option value="chai">Chai-1</option>
-              <option value="alphafold">AlphaFold 2</option>
               <option value="esmfold">ESMFold</option>
             </select>
           </div>


### PR DESCRIPTION
AlphaFold 2 has been retired from the PredictStructure service's automatic tool selection (CEPI-dxkb/PredictStructureApp#90). It remains fully runnable when named explicitly — via the API with `tool: "alphafold"`, the `predict-structure` CLI, or the AlphaFold CWL tool — so existing jobs and saved job specs stay reproducible. It should simply no longer be offered as a choice to new users.

## Changes

- Drop `<option value="alphafold">AlphaFold 2</option>` from the tool dropdown
- `applicationDescription` no longer lists AlphaFold 2
- Remove the `alphafold` branch of `_refreshMsaPolicyMessage()`, unreachable once the option is gone

## Notes

The Auto-mode MSA message already reads *"With no MSA the service falls back to ESMFold for a single protein chain"* — which is exactly the post-retirement behavior. AlphaFold used to be the last resort in that chain and no longer is, so that text needed no change.

The MSA file prompt on `alpha` already avoids mentioning AlphaFold, so it is untouched too.

## Why the service keeps AlphaFold in its app spec

On the service side the `tool` enum still contains `"alphafold"` deliberately — that is the API contract, and removing it would break direct submissions. The retirement is specifically about auto-selection and the UI, not about removing the capability. Tests were added there to pin the enum so it cannot be deleted by mistake.

## Verification

No `alphafold` references remain in `PredictStructure.js` or `PredictStructure.html`. The remaining tools in the selector are Auto, Boltz-2, OpenFold 3, Chai-1, ESMFold.