### PR TITLE
PredictStructure: set runtime expectations in the submitted message

### DIFF
--- a/public/js/p3/widget/app/PredictStructure.js
+++ b/public/js/p3/widget/app/PredictStructure.js
@@ -65,12 +65,30 @@ define([
       this.onToolChange();
     },
 
+    // #51: no per-job progress is available (the prediction tools emit none),
+    // so set expectations instead — the Jobs List shows queued/running, and
+    // this tells the user what a normal wait looks like for their tool.
+    _runtimeHints: {
+      esmfold: 'ESMFold typically finishes in minutes.',
+      boltz: 'Boltz typically takes a few minutes for small proteins; large complexes and MSA-server jobs can take an hour or more.',
+      openfold: 'OpenFold 3 typically takes a few minutes for small proteins; large complexes and MSA-server jobs can take an hour or more.',
+      chai: 'Chai-1 typically takes a few minutes for small proteins; large complexes and MSA-server jobs can take an hour or more.',
+      auto: 'Small proteins typically finish in minutes; large complexes and MSA-server jobs can take an hour or more.'
+    },
+
+    _refreshRuntimeHint: function () {
+      if (!this.runtimeHint) { return; }
+      var tool = this.tool ? this.tool.get('value') : 'auto';
+      this.runtimeHint.innerHTML = this._runtimeHints[tool] || this._runtimeHints.auto;
+    },
+
     openJobsList: function () {
       Topic.publish('/navigate', { href: '/job/' });
     },
 
     onToolChange: function () {
       this._refreshMsaPolicyMessage();
+      this._refreshRuntimeHint();
       this.checkParameterRequiredFields();
     },
 

--- a/public/js/p3/widget/app/templates/PredictStructure.html
+++ b/public/js/p3/widget/app/templates/PredictStructure.html
@@ -215,6 +215,7 @@
         Your job has been submitted successfully. Please visit your <a
           data-dojo-attach-event="onclick:openJobsList"><u>Jobs List</u> </a>to check the status of your job and access
         the results.
+        <div data-dojo-attach-point="runtimeHint" style="margin-top:6px; font-style:italic;"></div>
       </div>
       <div style="margin-top: 10px; text-align:center;">
         <div data-dojo-attach-point="cancelButton" data-dojo-attach-event="onClick:onCancel"


### PR DESCRIPTION
Requested in CEPI-dxkb/PredictStructureApp#51 by @architvasan.

A true per-job progress bar is not feasible from the service side: the prediction tools emit no progress, and the scheduler knows only queued/running/completed — which the Jobs List already shows. What users actually lack between submission and completion is a sense of whether a long silence is *normal*.

This adds a per-tool runtime hint to the post-submit message (already linked to the Jobs List), refreshed when the tool selection changes:

- ESMFold: *typically finishes in minutes*
- Boltz / OpenFold 3 / Chai-1: *a few minutes for small proteins; large complexes and MSA-server jobs can take an hour or more*

The numbers come from the service's own acceptance runs (ESMFold ~40 s, diffusion tools 2–4 min on small proteins with an uploaded MSA, longer via the MSA server).

Anything beyond this — live percent-complete — needs tool-level progress reporting plus scheduler plumbing, which is a platform feature rather than a PredictStructure one.