### PR TITLE
PredictStructure: offer ESMFold2 in the tool selector

### DIFF
--- a/public/js/p3/widget/app/PredictStructure.js
+++ b/public/js/p3/widget/app/PredictStructure.js
@@ -16,7 +16,7 @@ define([
     applicationName: 'PredictStructure',
     requireAuth: true,
     applicationLabel: 'Protein Structure Prediction',
-    applicationDescription: 'Predict biomolecular structures (proteins, complexes, protein-DNA/RNA, protein-ligand) using Boltz, OpenFold 3, Chai, AlphaFold 2, or ESMFold. Provides a unified interface with automatic parameter mapping, format conversion, output normalization, and confidence scoring.',
+    applicationDescription: 'Predict biomolecular structures (proteins, complexes, protein-DNA/RNA, protein-ligand) using Boltz, OpenFold 3, Chai, AlphaFold 2, ESMFold, or ESMFold2. Provides a unified interface with automatic parameter mapping, format conversion, output normalization, and confidence scoring.',
     applicationHelp: 'quick_references/services/predict_structure_service.html',
     tutorialLink: 'tutorial/predict_structure/predict_structure.html',
     videoLink: '',
@@ -80,6 +80,8 @@ define([
       var msg;
       if (tool === 'esmfold') {
         msg = 'ESMFold does not use an MSA; this section is ignored.';
+      } else if (tool === 'esmfold2') {
+        msg = 'Optional. ESMFold2 can use a <i>Precomputed MSA from Workspace</i> for better accuracy on hard targets. <i>Use MSA Server or Service</i> is NOT available for ESMFold2 — selecting it folds single-sequence.';
       } else if (tool === 'alphafold') {
         msg = 'AlphaFold 2 builds its own MSA from BV-BRC databases; this section is ignored.';
       } else if (tool === 'boltz' || tool === 'openfold' || tool === 'chai') {

--- a/public/js/p3/widget/app/templates/PredictStructure.html
+++ b/public/js/p3/widget/app/templates/PredictStructure.html
@@ -41,6 +41,7 @@
               <option value="chai">Chai-1</option>
               <option value="alphafold">AlphaFold 2</option>
               <option value="esmfold">ESMFold</option>
+              <option value="esmfold2">ESMFold2</option>
             </select>
           </div>
         </div>


### PR DESCRIPTION
The service has accepted `tool: esmfold2` since CEPI-dxkb/PredictStructureApp#44, and it is now verified end-to-end in production (CEPI-dxkb/PredictStructureApp#75 — protein, protein+SMILES, protein+DNA, and protein+uploaded-MSA all pass; typical runtime ~1 minute for small proteins on H200). But the UI never gained the option, so users could only reach it via the API.

## Changes

- `<option value="esmfold2">ESMFold2</option>` in the tool dropdown
- A dedicated MSA-policy message stating the asymmetry honestly: an **uploaded** MSA works and improves hard targets (upstream reports ipTM 0.19 → 0.85 on PDB 7YTU), but **Use MSA Server is NOT available** for ESMFold2 — the `esm` package ships no server client (CEPI-dxkb/PredictStructureApp#96), and selecting it folds single-sequence
- `applicationDescription` updated

## Note for whichever PR lands last

If #1398 (runtime hints) merges too, the hints map needs one line: `esmfold2: 'ESMFold2 typically finishes in a few minutes.'` — happy to rebase either PR on the other.