### PR TITLE
PredictStructure UI: retire AlphaFold 2, add ESMFold2, set runtime expectations

### DIFF
--- a/public/js/p3/widget/app/PredictStructure.js
+++ b/public/js/p3/widget/app/PredictStructure.js
@@ -65,12 +65,30 @@ define([
       this.onToolChange();
     },
 
+    // #51: no per-job progress is available (the prediction tools emit none),
+    // so set expectations instead — the Jobs List shows queued/running, and
+    // this tells the user what a normal wait looks like for their tool.
+    _runtimeHints: {
+      esmfold: 'ESMFold typically finishes in minutes.',
+      boltz: 'Boltz typically takes a few minutes for small proteins; large complexes and MSA-server jobs can take an hour or more.',
+      openfold: 'OpenFold 3 typically takes a few minutes for small proteins; large complexes and MSA-server jobs can take an hour or more.',
+      chai: 'Chai-1 typically takes a few minutes for small proteins; large complexes and MSA-server jobs can take an hour or more.',
+      auto: 'Small proteins typically finish in minutes; large complexes and MSA-server jobs can take an hour or more.'
+    },
+
+    _refreshRuntimeHint: function () {
+      if (!this.runtimeHint) { return; }
+      var tool = this.tool ? this.tool.get('value') : 'auto';
+      this.runtimeHint.innerHTML = this._runtimeHints[tool] || this._runtimeHints.auto;
+    },
+
     openJobsList: function () {
       Topic.publish('/navigate', { href: '/job/' });
     },
 
     onToolChange: function () {
       this._refreshMsaPolicyMessage();
+      this._refreshRuntimeHint();
       this.checkParameterRequiredFields();
     },
 

--- a/public/js/p3/widget/app/PredictStructure.js
+++ b/public/js/p3/widget/app/PredictStructure.js
@@ -105,7 +105,7 @@ define([
         msg = 'Required for the selected prediction tool. Choose <i>Precomputed MSA from Workspace</i> to upload one, or <i>Use MSA Server or Service</i> to have BV-BRC compute one with ColabFold.';
       } else {
         // tool === 'auto' (or unknown)
-        msg = 'Optional in Auto mode. With no MSA the service falls back to ESMFold for a single protein chain.';
+        msg = 'Optional in Auto mode. With no MSA uploaded, the service computes one automatically with ColabFold and Auto picks Boltz. For the fastest single-protein result pick ESMFold or ESMFold2 directly.';
       }
       this.msa_policy_message.innerHTML = msg;
     },

--- a/public/js/p3/widget/app/PredictStructure.js
+++ b/public/js/p3/widget/app/PredictStructure.js
@@ -16,7 +16,7 @@ define([
     applicationName: 'PredictStructure',
     requireAuth: true,
     applicationLabel: 'Protein Structure Prediction',
-    applicationDescription: 'Predict biomolecular structures (proteins, complexes, protein-DNA/RNA, protein-ligand) using Boltz, OpenFold 3, Chai, AlphaFold 2, or ESMFold. Provides a unified interface with automatic parameter mapping, format conversion, output normalization, and confidence scoring.',
+    applicationDescription: 'Predict biomolecular structures (proteins, complexes, protein-DNA/RNA, protein-ligand) using Boltz, OpenFold 3, Chai, or ESMFold. Provides a unified interface with automatic parameter mapping, format conversion, output normalization, and confidence scoring.',
     applicationHelp: 'quick_references/services/predict_structure_service.html',
     tutorialLink: 'tutorial/predict_structure/predict_structure.html',
     videoLink: '',
@@ -80,8 +80,6 @@ define([
       var msg;
       if (tool === 'esmfold') {
         msg = 'ESMFold does not use an MSA; this section is ignored.';
-      } else if (tool === 'alphafold') {
-        msg = 'AlphaFold 2 builds its own MSA from BV-BRC databases; this section is ignored.';
       } else if (tool === 'boltz' || tool === 'openfold' || tool === 'chai') {
         msg = 'Required for the selected prediction tool. Choose <i>Precomputed MSA from Workspace</i> to upload one, or <i>Use MSA Server or Service</i> to have BV-BRC compute one with ColabFold.';
       } else {

--- a/public/js/p3/widget/app/PredictStructure.js
+++ b/public/js/p3/widget/app/PredictStructure.js
@@ -16,7 +16,7 @@ define([
     applicationName: 'PredictStructure',
     requireAuth: true,
     applicationLabel: 'Protein Structure Prediction',
-    applicationDescription: 'Predict biomolecular structures (proteins, complexes, protein-DNA/RNA, protein-ligand) using Boltz, OpenFold 3, Chai, AlphaFold 2, or ESMFold. Provides a unified interface with automatic parameter mapping, format conversion, output normalization, and confidence scoring.',
+    applicationDescription: 'Predict biomolecular structures (proteins, complexes, protein-DNA/RNA, protein-ligand) using Boltz, OpenFold 3, Chai, AlphaFold 2, ESMFold, or ESMFold2. Provides a unified interface with automatic parameter mapping, format conversion, output normalization, and confidence scoring.',
     applicationHelp: 'quick_references/services/predict_structure_service.html',
     tutorialLink: 'tutorial/predict_structure/predict_structure.html',
     videoLink: '',
@@ -80,6 +80,8 @@ define([
       var msg;
       if (tool === 'esmfold') {
         msg = 'ESMFold does not use an MSA; this section is ignored.';
+      } else if (tool === 'esmfold2') {
+        msg = 'Optional. ESMFold2 can use a <i>Precomputed MSA from Workspace</i> for better accuracy on hard targets. <i>Use MSA Server or Service</i> is NOT available for ESMFold2 — selecting it folds single-sequence.';
       } else if (tool === 'alphafold') {
         msg = 'AlphaFold 2 builds its own MSA from BV-BRC databases; this section is ignored.';
       } else if (tool === 'boltz' || tool === 'openfold' || tool === 'chai') {

--- a/public/js/p3/widget/app/templates/PredictStructure.html
+++ b/public/js/p3/widget/app/templates/PredictStructure.html
@@ -41,6 +41,7 @@
               <option value="chai">Chai-1</option>
               <option value="alphafold">AlphaFold 2</option>
               <option value="esmfold">ESMFold</option>
+              <option value="esmfold2">ESMFold2</option>
             </select>
           </div>
         </div>

--- a/public/js/p3/widget/app/templates/PredictStructure.html
+++ b/public/js/p3/widget/app/templates/PredictStructure.html
@@ -39,7 +39,6 @@
               <option value="boltz">Boltz-2</option>
               <option value="openfold">OpenFold 3</option>
               <option value="chai">Chai-1</option>
-              <option value="alphafold">AlphaFold 2</option>
               <option value="esmfold">ESMFold</option>
             </select>
           </div>

--- a/public/js/p3/widget/app/templates/PredictStructure.html
+++ b/public/js/p3/widget/app/templates/PredictStructure.html
@@ -215,6 +215,7 @@
         Your job has been submitted successfully. Please visit your <a
           data-dojo-attach-event="onclick:openJobsList"><u>Jobs List</u> </a>to check the status of your job and access
         the results.
+        <div data-dojo-attach-point="runtimeHint" style="margin-top:6px; font-style:italic;"></div>
       </div>
       <div style="margin-top: 10px; text-align:center;">
         <div data-dojo-attach-point="cancelButton" data-dojo-attach-event="onClick:onCancel"


### PR DESCRIPTION
Consolidated PR — reviewed, fixed, and merged in the fork first (wilke/BV-BRC-Web#1). Supersedes #1397, #1398, #1399, which will be closed in its favor.

## Changes

**Remove AlphaFold 2 from the tool selector.** Retired from automatic selection service-side (CEPI-dxkb/PredictStructureApp#90); it stays fully runnable via API/CLI (`tool: "alphafold"`), so saved job specs keep working. Also removes the now-unreachable alphafold branch of the MSA-policy message.

**Offer ESMFold2.** Selectable and verified end-to-end in production (PredictStructureApp#75 — protein, protein+SMILES, protein+DNA, protein+uploaded-MSA all pass; ~1 min for small proteins). Its MSA-policy message states the asymmetry plainly: an uploaded `.a3m` works and improves hard targets; *Use MSA Server* is **not** available for ESMFold2 (the `esm` package ships no server client) and selecting it folds single-sequence.

**Runtime expectations in the submitted message** (PredictStructureApp#51, @architvasan). No per-job progress exists to display — the tools emit none and the scheduler knows only queued/running/completed, which the Jobs List already shows. What users lack is whether a long silence is normal; the post-submit message now carries a per-tool hint from real acceptance timings, refreshed on tool change and populated at startup via `postCreate → onToolChange`.

**One factual correction to pre-existing text**: the Auto/no-MSA message claimed the service falls back to ESMFold. It doesn't — the service auto-enables the ColabFold MSA server and Auto resolves to Boltz (confirmed by the service's acceptance matrix). Message now says so, and points at ESMFold/ESMFold2 for the fastest single-protein path.

## Verification

Served from a local p3-web and inspected: dropdown = Auto / Boltz-2 / OpenFold 3 / Chai-1 / ESMFold / ESMFold2; zero `alphafold` references in template+JS; `node --check` clean; hints map covers all six tools; all template attach-points unique.

Companion docs PR: BV-BRC-Docs (consolidated, same review cycle).