### PR TITLE
Add REPORT eye-icon actions for PredictStructure and StabiliNNator

### DIFF
--- a/public/js/p3/widget/WorkspaceBrowser.js
+++ b/public/js/p3/widget/WorkspaceBrowser.js
@@ -1057,6 +1057,63 @@ define([
           }
         }
       );
+      this.browserHeader.addAction(
+        "ViewPredictStructureReport",
+        "fa icon-eye fa-2x",
+        {
+          label: "REPORT",
+          multiple: false,
+          validTypes: ["PredictStructure"],
+          tooltip: "View Structure Prediction Report",
+        },
+        function (selection) {
+          var path;
+          selection[0].autoMeta.output_files.forEach(
+            lang.hitch(this, function (file_data) {
+              var filepath = file_data[0].split("/");
+              if (filepath[filepath.length - 1] === "report.html") {
+                path = filepath.join("/");
+              }
+            })
+          );
+          if (path) {
+            Topic.publish("/navigate", { href: "/workspace" + encodePath(path) });
+          } else {
+            console.log("Error: could not find report.html");
+          }
+        }
+      );
+      this.browserHeader.addAction(
+        "ViewStabiliNNatorReport",
+        "fa icon-eye fa-2x",
+        {
+          label: "REPORT",
+          multiple: false,
+          validTypes: ["StabiliNNator"],
+          tooltip: "View Protein Stability Report",
+        },
+        function (selection) {
+          var path;
+          // StabiliNNator names its report after the input structure
+          // (<basename>_report.html), so match the suffix rather than a
+          // fixed filename as the other report actions do.
+          selection[0].autoMeta.output_files.forEach(
+            lang.hitch(this, function (file_data) {
+              var filepath = file_data[0].split("/");
+              var filename = filepath[filepath.length - 1];
+              if (filename.length > "_report.html".length &&
+                  filename.slice(-"_report.html".length) === "_report.html") {
+                path = filepath.join("/");
+              }
+            })
+          );
+          if (path) {
+            Topic.publish("/navigate", { href: "/workspace" + encodePath(path) });
+          } else {
+            console.log("Error: could not find <basename>_report.html");
+          }
+        }
+      );
 
       // TODO: Paired_Filter report??
       this.browserHeader.addAction('ViewFastqUtilsOutput', 'fa icon-eye fa-2x', {

--- a/public/js/p3/widget/WorkspaceBrowser.js
+++ b/public/js/p3/widget/WorkspaceBrowser.js
@@ -1077,7 +1077,9 @@ define([
             })
           );
           if (path) {
-            Topic.publish("/navigate", { href: "/workspace" + encodePath(path) });
+            // Open in a new tab so the user keeps their place in the
+            // workspace listing; the report is a destination, not a step.
+            window.open("/workspace" + encodePath(path), "_blank");
           } else {
             console.log("Error: could not find report.html");
           }
@@ -1108,7 +1110,7 @@ define([
             })
           );
           if (path) {
-            Topic.publish("/navigate", { href: "/workspace" + encodePath(path) });
+            window.open("/workspace" + encodePath(path), "_blank");
           } else {
             console.log("Error: could not find <basename>_report.html");
           }


### PR DESCRIPTION
Both services produce an HTML report but have no eye icon in the workspace browser, so users must open the result folder and hunt for the report file. Every other report-producing service has one — Docking, CoreGenomeMLST, SARS2Wastewater, WholeGenomeSNPAnalysis and ~27 others. Follows the pattern established by #1329.

Two actions, because the two services name their reports differently:

- **PredictStructure** promotes a fixed `report.html` to the top of its output folder — matched exactly, as Docking matches `small_molecule_docking_report.html`.
- **StabiliNNator** names its report after the input structure (`${basename}_report.html`, e.g. `1crn_small_report.html`), so a fixed-string match would never fire. That action matches the `_report.html` suffix, with a length guard so a bare `report.html` cannot match it.

## Verified against real job output

- **The type check looks wrong but is right.** Both job objects carry the generic workspace type `job_result` (a BLAST job has the same). `ActionBar.js:45-53` substitutes `autoMeta.app.id` for `job_result` selections, and on a completed job `app.id === "PredictStructure"`. The StabiliNNator app spec declares `id: StabiliNNator`.
- `report.html` confirmed present in a real job's `output_files` (22 entries) and in the workspace folder.
- Matching logic exercised against both services' actual filename lists: each action selects only its own report, and the `reports/` *folder* entry in PredictStructure output matches neither.
- **Failed jobs are safe:** a failed job carries `output_files: []`, so the icon appears but the handler logs and does nothing rather than throwing — identical to the existing Docking behaviour.
- File parses under node and is served correctly by a local p3-web instance.

Resolves the PredictStructure half of CEPI-dxkb/PredictStructureApp#88.

Not done: visual click-through in a running UI. Happy to add anything you'd like before merge.