### PR TITLE
feat: add StabiliNNator submission form

### DIFF
--- a/public/js/p3/widget/RerunUtility.js
+++ b/public/js/p3/widget/RerunUtility.js
@@ -35,6 +35,7 @@ define([], function () {
         'MetagenomicReadMapping': 'MetagenomicReadMapping',
         'MSA': 'MSA',
         'PredictStructure': 'PredictStructure',
+        'StabiliNNator': 'StabiliNNator',
         'CodonTree': 'PhylogeneticTree',
         'PrimerDesign': 'PrimerDesign',
         'RNASeq': 'Rnaseq',

--- a/public/js/p3/widget/WorkspaceBrowser.js
+++ b/public/js/p3/widget/WorkspaceBrowser.js
@@ -1096,9 +1096,12 @@ define([
         },
         function (selection) {
           var path;
-          // StabiliNNator names its report after the input structure
-          // (<basename>_report.html), so match the suffix rather than a
-          // fixed filename as the other report actions do.
+          // Match on the "_report.html" suffix rather than a fixed filename as
+          // the other report actions do. StabiliNNator now writes a fixed
+          // stabilinnator_report.html, but jobs completed before that change
+          // named the report after the input structure
+          // (<basename>_report.html). The suffix match covers both, so it must
+          // stay until those legacy results are gone.
           selection[0].autoMeta.output_files.forEach(
             lang.hitch(this, function (file_data) {
               var filepath = file_data[0].split("/");

--- a/public/js/p3/widget/app/StabiliNNator.js
+++ b/public/js/p3/widget/app/StabiliNNator.js
@@ -1,0 +1,190 @@
+define([
+  'dojo/_base/declare', 'dojo/topic',
+  'dijit/_TemplatedMixin', 'dijit/_WidgetsInTemplateMixin',
+  'dojo/text!./templates/StabiliNNator.html', './AppBase',
+  '../../WorkspaceManager',
+  'dijit/form/Button', 'dijit/form/Select',
+  'p3/widget/WorkspaceFilenameValidationTextBox', 'p3/widget/WorkspaceObjectSelector'
+], function (
+  declare, Topic,
+  Templated, WidgetsInTemplate,
+  Template, AppBase, WorkspaceManager
+) {
+  return declare([AppBase], {
+    baseClass: 'StabiliNNator',
+    templateString: Template,
+    applicationName: 'StabiliNNator',
+    requireAuth: true,
+    applicationLabel: 'Protein Stability Prediction',
+    applicationDescription: 'Identify positions in a protein structure where a targeted mutation is likely to increase thermal stability. Two graph neural networks score every residue: proliNNator for favorable proline substitutions and disulfiNNate for likely disulfide bonds. Probabilities are returned in the B-factor column of an annotated PDB, alongside ranked summaries and an interactive report.',
+    applicationHelp: 'quick_references/services/stabilinnator_service.html',
+    tutorialLink: 'tutorial/stabilinnator/stabilinnator.html',
+    videoLink: '',
+    pageTitle: 'Protein Stability Prediction Service | BV-BRC',
+    required: true,
+    defaultPath: '',
+
+    startup: function () {
+      var _self = this;
+      if (this._started) { return; }
+      this.inherited(arguments);
+      if (this.requireAuth && (window.App.authorizationToken === null || window.App.authorizationToken === undefined)) {
+        return;
+      }
+      _self.defaultPath = WorkspaceManager.getDefaultFolder() || _self.activeWorkspacePath;
+      _self.output_path.set('value', _self.defaultPath);
+      this.form_flag = false;
+      try {
+        this.intakeRerunForm();
+      } catch (error) {
+        console.error(error);
+      }
+      // Default Job Name = <applicationName>-yymmdd-hhmmss, unless rerun-form
+      // intake (or a stored value) already filled it. The service rejects a
+      // submission with no output_file, and results are written to
+      // <output_path>/.<output_file>/, so every run needs its own name.
+      if (this.output_file && !this.output_file.get('value')) {
+        this.output_file.set('value', this._defaultJobName());
+      }
+      this.updateOutputPathPreview();
+      this.checkParameterRequiredFields();
+    },
+
+    _defaultJobName: function () {
+      var d = new Date();
+      var pad = function (n) { return n < 10 ? '0' + n : String(n); };
+      var stamp = pad(d.getFullYear() % 100) + pad(d.getMonth() + 1) + pad(d.getDate())
+        + '-' + pad(d.getHours()) + pad(d.getMinutes()) + pad(d.getSeconds());
+      return (this.applicationName || 'job') + '-' + stamp;
+    },
+
+    postCreate: function () {
+      this.inherited(arguments);
+      this.onAnalysisTypeChange();
+    },
+
+    openJobsList: function () {
+      Topic.publish('/navigate', { href: '/job/' });
+    },
+
+    // Both analyses are independent and each is sub-second; the wall time a
+    // user actually sees is container staging. Set that expectation rather
+    // than implying the analysis choice changes the wait.
+    onAnalysisTypeChange: function () {
+      if (this.analysis_message) {
+        var t = this.analysis_type ? this.analysis_type.get('value') : 'both';
+        var msg;
+        if (t === 'proline') {
+          msg = 'Scores every residue for substitution to proline. Positions that are already proline tend to score high and are flagged in the summary as <i>already PRO</i>.';
+        } else if (t === 'disulfide') {
+          msg = 'Scores cysteines for their likelihood of forming a disulfide bond. The annotated PDB carries a value on every residue, but only cysteines are meaningful; the ranked summary is filtered to them.';
+        } else {
+          msg = 'Runs both analyses. They are independent, and together take only a few seconds longer than either alone.';
+        }
+        this.analysis_message.innerHTML = msg;
+      }
+      this.checkParameterRequiredFields();
+    },
+
+    getValues: function () {
+      var values = this.inherited(arguments);
+      // Build the submission explicitly. Anything not in the app spec makes
+      // AppScript::preprocess_parameters warn about unknown parameters, so
+      // only send fields the spec declares.
+      var submit = {
+        input_file: values.input_file,
+        analysis_type: values.analysis_type || 'both',
+        output_path: values.output_path,
+        output_file: values.output_file
+      };
+      if (values.theme) { submit.theme = values.theme; }
+      return submit;
+    },
+
+    _hasInput: function () {
+      return !!(this.input_file && this.input_file.get('value'));
+    },
+
+    validate: function () {
+      var valid = this.inherited(arguments);
+      if (!valid || !this._hasInput()) {
+        if (this.submitButton) { this.submitButton.set('disabled', true); }
+        return false;
+      }
+      return valid;
+    },
+
+    checkParameterRequiredFields: function () {
+      if (
+        this._hasInput()
+        && this.output_path.get('value')
+        && this.output_file && this.output_file.get('value')
+      ) {
+        this.validate();
+      } else {
+        if (this.submitButton) {
+          this.submitButton.set('disabled', true);
+        }
+      }
+    },
+
+    onOutputPathChange: function (val) {
+      this.inherited(arguments);
+      this.updateOutputPathPreview();
+      this.checkParameterRequiredFields();
+    },
+
+    checkOutputName: function (val) {
+      this.inherited(arguments);
+      this.updateOutputPathPreview();
+      this.checkParameterRequiredFields();
+    },
+
+    updateOutputPathPreview: function () {
+      if (!this.output_path_preview) { return; }
+      var folder = this.output_path && this.output_path.get('value');
+      var name = this.output_file && this.output_file.get('value');
+      if (folder && name) {
+        var f = String(folder).replace(/\/+$/, '');
+        var n = String(name).replace(/^\/+/, '');
+        this.output_path_preview.textContent = f + '/' + n;
+      } else if (folder) {
+        this.output_path_preview.textContent = String(folder).replace(/\/+$/, '') + '/(enter Job Name)';
+      } else {
+        this.output_path_preview.textContent = '(set Output Folder and Job Name)';
+      }
+    },
+
+    addRerunFields: function (job_params) {
+      if (job_params.input_file) { this.input_file.set('value', job_params.input_file); }
+      if (job_params.analysis_type) { this.analysis_type.set('value', job_params.analysis_type); }
+      if (job_params.theme && this.theme) { this.theme.set('value', job_params.theme); }
+      if (job_params.output_path) { this.output_path.set('value', job_params.output_path); }
+      if (job_params.output_file) { this.output_file.set('value', job_params.output_file); }
+
+      this.onAnalysisTypeChange();
+    },
+
+    intakeRerunForm: function () {
+      var service_fields = window.location.search.replace('?', '');
+      var rerun_fields = service_fields.split('=');
+      var rerun_key;
+      if (rerun_fields.length > 1) {
+        rerun_key = rerun_fields[1];
+        var sessionStorage = window.sessionStorage;
+        if (sessionStorage.hasOwnProperty(rerun_key)) {
+          try {
+            var param_dict = { 'output_folder': 'output_path' };
+            AppBase.prototype.intakeRerunFormBase.call(this, param_dict);
+            this.addRerunFields(JSON.parse(sessionStorage.getItem(rerun_key)));
+            this.form_flag = true;
+          } catch (error) {
+            console.log('Error during intakeRerunForm: ', error);
+          } finally {
+            sessionStorage.removeItem(rerun_key);
+          }
+        }
+      }
+    }
+  });
+});

--- a/public/js/p3/widget/app/templates/StabiliNNator.html
+++ b/public/js/p3/widget/app/templates/StabiliNNator.html
@@ -1,0 +1,148 @@
+<form dojoAttachPoint="containerNode" class="PanelForm App ${baseClass}"
+  dojoAttachEvent="onreset:_onReset,onsubmit:_onSubmit,onchange:validate">
+  <div class="appTemplate">
+    <div class="appTitle">
+      <span class="breadcrumb">Services</span>
+      <h1 class="appHeader">${applicationLabel}
+        <div name="overview" class="infobox iconbox infobutton dialoginfo">
+          <i class="fa icon-info-circle fa" title="click to open info dialog"></i>
+        </div>
+        <div class="infobox iconbox tutorialButton tutorialInfo">
+          <a href="${docsServiceURL}${tutorialLink}" target="_blank"><i class="fa icon-books fa-1x"
+              title="click to open tutorial"></i></a>
+        </div>
+      </h1>
+      <p>${applicationDescription} For further explanation, please see the ${applicationLabel} Service <a
+          href="${docsServiceURL}${applicationHelp}" target="_blank">Quick Reference Guide</a> and <a
+          href="${docsServiceURL}${tutorialLink}" target="_blank">Tutorial</a>.</p>
+    </div>
+
+    <div style="width:85%; margin:auto" class="formFieldsContainer">
+
+      <!-- Input Structure -->
+      <div style="width:97%;" class="appBox appShadow">
+        <div class="headerrow">
+          <div style="width:85%;display:inline-block;">
+            <label class="appBoxLabel">Input Structure</label>
+            <div name="input-structure" class="infobox iconbox infobutton dialoginfo">
+              <i class="fa icon-info-circle fa" title="click to open info dialog"></i>
+            </div>
+          </div>
+        </div>
+        <br>
+        <div class="appRow">
+          <div class="appFieldLong">
+            <label>Protein Structure</label><br>
+            <div data-dojo-type="p3/widget/WorkspaceObjectSelector" name="input_file" style="width:75%;"
+              data-dojo-attach-point="input_file"
+              data-dojo-attach-event="onChange:checkParameterRequiredFields"
+              data-dojo-props="type:['txt','unspecified','pdb'],multi:false,promptMessage:'Protein structure in PDB or mmCIF format. Must contain standard amino acids with CA atoms. Multi-model files (NMR ensembles) are collapsed to the first model. A structure from the Protein Structure Prediction service can be used directly.',missingMessage:'An input structure is required.',placeHolder:'PDB or mmCIF structure file'">
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Analysis -->
+      <div style="width:97%;" class="appBox appShadow">
+        <div class="headerrow">
+          <div style="width:85%;display:inline-block;">
+            <label class="appBoxLabel">Analysis</label>
+            <div name="analysis" class="infobox iconbox infobutton dialoginfo">
+              <i class="fa icon-info-circle fa" title="click to open info dialog"></i>
+            </div>
+          </div>
+        </div>
+        <div class="appRow">
+          <div class="appFieldLong" style="width:380px">
+            <label>Analysis Type</label><br>
+            <select data-dojo-type="dijit/form/Select" data-dojo-attach-point="analysis_type"
+              name="analysis_type" style="width:100%;"
+              data-dojo-attach-event="onChange:onAnalysisTypeChange"
+              data-dojo-props="value:'both'">
+              <option value="both" selected>Both</option>
+              <option value="proline">Proline sites (proliNNator)</option>
+              <option value="disulfide">Disulfide sites (disulfiNNate)</option>
+            </select>
+            <div data-dojo-attach-point="analysis_message" style="margin-top:4px; color:#666;"></div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Output -->
+      <div style="width:97%;" class="appBox appShadow">
+        <div class="headerrow">
+          <div style="width:85%;display:inline-block;">
+            <label class="appBoxLabel">Output</label>
+            <div name="output" class="infobox iconbox infobutton dialoginfo">
+              <i class="fa icon-info-circle fa" title="click to open info dialog"></i>
+            </div>
+          </div>
+        </div>
+        <div class="appRow">
+          <div class="appFieldLong" style="width:380px">
+            <label>Report Theme</label><br>
+            <select data-dojo-type="dijit/form/Select" data-dojo-attach-point="theme"
+              name="theme" style="width:100%;"
+              data-dojo-props="value:'bvbrc'">
+              <option value="bvbrc" selected>BV-BRC</option>
+              <option value="editorial">Editorial</option>
+            </select>
+          </div>
+        </div>
+        <div class="appRow">
+          <div class="appFieldLong">
+            <label>Output Folder</label><br>
+            <div data-dojo-attach-point="output_path" data-dojo-type="p3/widget/WorkspaceObjectSelector"
+              name="output_path" style="width:75%" required="true"
+              data-dojo-props="title:'Select an Output Folder',autoSelectCurrent:true,selectionText:'Destination',type:['folder'],multi:false,value:'${activeWorkspacePath}',workspace:'${activeWorkspace}',promptMessage:'Workspace folder for stability prediction results.',missingMessage:'Output Folder must be selected.'"
+              data-dojo-attach-event="onChange:onOutputPathChange">
+            </div>
+          </div>
+        </div>
+        <div class="appRow">
+          <div class="appFieldLong" style="width:380px">
+            <label>Job Name</label><span class="charError"
+              style="color:red; font-size:8pt; padding-left:10px; font-weight:bold">&nbsp;</span><br>
+            <div data-dojo-attach-point="output_file" data-dojo-attach-event="onChange:checkOutputName"
+              style="width:100%;"
+              data-dojo-type="p3/widget/WorkspaceFilenameValidationTextBox" name="output_file"
+              data-dojo-props="intermediateChanges:true, promptMessage:'Name for this job. A workspace object with this name is created inside the Output Folder and holds all job-related info including the prediction results.',trim:true,placeHolder:'Job name'">
+            </div>
+          </div>
+        </div>
+        <div class="appRow">
+          <div class="appFieldLong" style="margin-top:8px; padding:8px 12px; background:#f5f5f5; border-left:3px solid #6e8baf; font-family:monospace; font-size:12px; color:#333;">
+            <span style="color:#6e8baf; font-weight:bold;">Result location:</span>
+            <span data-dojo-attach-point="output_path_preview">(set Output Folder and Job Name)</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="appSubmissionArea">
+      <div data-dojo-attach-point="workingMessage" class="messageContainer workingMessage"
+        style="margin-top:10px; text-align:center;">
+        Submitting Protein Stability Prediction Job
+      </div>
+      <div data-dojo-attach-point="errorMessage" class="messageContainer errorMessage"
+        style="margin-top:10px; text-align:center;">
+        Error Submitting Job
+      </div>
+      <div data-dojo-attach-point="submittedMessage" class="messageContainer submittedMessage"
+        style="margin-top:10px; text-align:center;">
+        Your job has been submitted successfully. Please visit your <a
+          data-dojo-attach-event="onclick:openJobsList"><u>Jobs List</u> </a>to check the status of your job and access
+        the results.
+        <div style="margin-top:6px; font-style:italic;">Most jobs finish in well under a minute; the wait is dominated by
+          staging the analysis container rather than by the prediction itself.</div>
+      </div>
+      <div style="margin-top: 10px; text-align:center;">
+        <div data-dojo-attach-point="cancelButton" data-dojo-attach-event="onClick:onCancel"
+          data-dojo-type="dijit/form/Button">Cancel
+        </div>
+        <div data-dojo-attach-point="resetButton" type="reset" data-dojo-type="dijit/form/Button">Reset</div>
+        <div data-dojo-attach-point="submitButton" type="submit" data-dojo-type="dijit/form/Button">Submit</div>
+      </div>
+    </div>
+  </div>
+</form>

--- a/public/js/p3/widget/app/templates/StabiliNNator.html
+++ b/public/js/p3/widget/app/templates/StabiliNNator.html
@@ -133,8 +133,9 @@
         Your job has been submitted successfully. Please visit your <a
           data-dojo-attach-event="onclick:openJobsList"><u>Jobs List</u> </a>to check the status of your job and access
         the results.
-        <div style="margin-top:6px; font-style:italic;">Most jobs finish in well under a minute; the wait is dominated by
-          staging the analysis container rather than by the prediction itself.</div>
+        <div style="margin-top:6px; font-style:italic;">The analysis itself takes seconds. Total time to results depends on
+          queue wait and on whether the analysis container is already staged on the assigned node, so a job may sit as
+          queued for a while before it runs.</div>
       </div>
       <div style="margin-top: 10px; text-align:center;">
         <div data-dojo-attach-point="cancelButton" data-dojo-attach-event="onClick:onCancel"

--- a/views/bv-brc-header.ejs
+++ b/views/bv-brc-header.ejs
@@ -219,6 +219,7 @@
                                     <div><a class="navigationLink" href="/app/ComparativeSystems">Comparative Systems</a></div>
                                     <div><a class="navigationLink" href="/app/Docking">Docking</a></div>
                                     <div><a class="navigationLink" href="/app/PredictStructure">Protein Structure Prediction</a></div>
+                                    <div><a class="navigationLink" href="/app/StabiliNNator">Protein Stability Prediction</a></div>
                                 </div>
                             </div>
 
@@ -507,6 +508,7 @@
                                 <div><a href="/app/ComparativeSystems">Comparative Systems</a></div>
                                 <div><a href="/app/Docking">Docking</a></div>
                                 <div><a href="/app/PredictStructure">Protein Structure Prediction</a></div>
+                                <div><a href="/app/StabiliNNator">Protein Stability Prediction</a></div>
                             </div>
                             <div class="menuHeader">Metagenomics</div>
                             <div class="sub-menu">

--- a/views/header.ejs
+++ b/views/header.ejs
@@ -768,6 +768,14 @@
 			keywords: "protein structure prediction, alphafold, boltz, esmfold, chai, openfold, bioinformatics"
 		},
 		{
+			name: "Protein Stability Prediction",
+			href: "/app/StabiliNNator",
+			title: "Protein Stability Prediction - Predict Stabilizing Mutations",
+			description: "Predict favorable proline substitutions and disulfide bond sites in a protein structure.",
+			robots: "index,follow",
+			keywords: "protein stability, proline, disulfide, stabilizing mutations, protein engineering, bioinformatics"
+		},
+		{
 			name: "Taxonomic Classification",
 			href: "/app/TaxonomicClassification",
 			title: "Taxonomic Classification - Classify Sequences into Categories",


### PR DESCRIPTION
Adds a submission form for the Protein Stability Prediction (StabiliNNator) service.

BV-BRC-Web#1403 added the REPORT eye-icon action for viewing a finished StabiliNNator job, but no form existed to create one — the service was reachable only through the API. `alpha` has zero StabiliNNator files today; this adds them.

## Changes

**New (2 files)** — `widget/app/StabiliNNator.js` and `widget/app/templates/StabiliNNator.html`, following the PredictStructure pattern. `/app/<Name>` resolves to `p3/widget/app/<Name>` in `p3app.js`, so no route or registry entry is needed.

**Wiring (3 files)**
- `views/header.ejs`, `views/bv-brc-header.ejs` — Protein Tools entries alongside Protein Structure Prediction (both menus)
- `widget/RerunUtility.js` — rerun support

**Also** — updates the stale comment on the REPORT action in `WorkspaceBrowser.js`. It said the report is named after the input structure; as of CEPI-dxkb/stabiliNNatorApp `486e037` the name is a fixed `stabilinnator_report.html`. **The suffix match is deliberately left in place**: jobs completed before that change still carry `<basename>_report.html` in their `output_files`, so it is load-bearing for legacy results and must not be simplified to an exact match yet.

## Form scope

Exposes `input_file`, `analysis_type`, `theme`, `output_path`, `output_file`. `accelerator`, `hidden_dim` and `dry_run` are deliberately not exposed — GPU gives no benefit for these models (CUDA init exceeds the compute saved), `hidden_dim` only applies to custom-trained models, and `dry_run` is a debugging aid. All three remain available through the API.

Two details carried over on purpose:
- Job Name is pre-filled `StabiliNNator-<yymmdd>-<hhmmss>`. The service rejects a submission with no `output_file`, and results land in `<output_path>/.<output_file>/`, so every run needs a distinct name.
- `getValues` builds the submission explicitly rather than passing the form through, so no field outside the app spec reaches the service.

## Testing

Verified against a local `p3-web` with a real submission to production.

Form behavior: renders with no console errors; `analysis_type` switches its helper text; output-folder autocomplete resolves; the Result-location preview updates live; Submit is correctly gated — disabled when empty **and** when the structure field is invalid, enabled only when valid. Compared against PredictStructure, which shows the same empty-Output-Folder and disabled-Submit baseline on a fresh load.

End-to-end: job `StabiliNNator-260825-175439` submitted from this form completed with `success: 1` and 6 `output_files` including `stabilinnator_report.html`. Parameters arrived exactly as the form built them. Analysis runtime was 8.8 s.

Lint: one pre-existing `use strict` error, the same class `PredictStructure.js` reports (it has ten).

## Docs

Quick-reference and API pages are in BV-BRC/BV-BRC-Docs#285. The form's info-icons resolve their content from the published quick-reference page by element id, so they will show "Help text missing" (gracefully) until that PR merges and publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETV3Yp5n9jJjfE9bvH1CNQ
