### PR TITLE
PredictStructure form: typed entity rows for Protein/DNA/RNA inputs

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -1,7 +1,8 @@
 {
   "testEnvironment": "node",
   "roots": [
-    "<rootDir>/public/js/p3/widget/copilot"
+    "<rootDir>/public/js/p3/widget/copilot",
+    "<rootDir>/public/js/p3/widget/app"
   ],
   "testMatch": [
     "**/tests/**/*.test.js"

--- a/public/js/p3/widget/app/PredictStructure.js
+++ b/public/js/p3/widget/app/PredictStructure.js
@@ -3,12 +3,14 @@ define([
   'dijit/_TemplatedMixin', 'dijit/_WidgetsInTemplateMixin',
   'dojo/text!./templates/PredictStructure.html', './AppBase',
   '../../WorkspaceManager',
+  'dojo/dom-style', 'dojo/dom-construct',
   'dijit/form/Button', 'dijit/form/Select', 'dijit/form/SimpleTextarea',
   'p3/widget/WorkspaceFilenameValidationTextBox', 'p3/widget/WorkspaceObjectSelector'
 ], function (
   declare, Topic,
   Templated, WidgetsInTemplate,
-  Template, AppBase, WorkspaceManager
+  Template, AppBase, WorkspaceManager,
+  domStyle, domConstruct
 ) {
   return declare([AppBase], {
     baseClass: 'PredictStructure',
@@ -60,9 +62,162 @@ define([
 
     postCreate: function () {
       this.inherited(arguments);
+      this._entityRowCount = 1;
+      this._refreshEntityRows();
       this._updateLigandLabel();
       this.onMsaSourceChange();
       this.onToolChange();
+    },
+
+    //
+    // Typed entity rows
+    // -----------------
+    // The form still submits input_file / dna_file / rna_file, unchanged --
+    // these rows only choose which selector is visible in which row. Three
+    // types, one file each, so at most three rows and each type used once.
+    //
+    _ENTITY_TYPES: [
+      { value: 'protein', label: 'Protein', slot: 'input_file' },
+      { value: 'dna', label: 'DNA', slot: 'dna_file' },
+      { value: 'rna', label: 'RNA', slot: 'rna_file' }
+    ],
+
+    _entityRowCount: 1,
+
+    _entityTypeOf: function (i) {
+      var sel = this['entityType' + i];
+      return sel && sel.value ? sel.value : null;
+    },
+
+    /** Types chosen by rows other than `except`. */
+    _entityTypesTaken: function (except) {
+      var taken = [];
+      for (var i = 0; i < this._entityRowCount; i++) {
+        if (i === except) { continue; }
+        var t = this._entityTypeOf(i);
+        if (t) { taken.push(t); }
+      }
+      return taken;
+    },
+
+    /**
+     * Rebuild row i's dropdown to offer only unused types (plus its own).
+     *
+     * Rebuilds ONLY when the option set actually changed. Emptying and
+     * recreating a <select> destroys the element the user is interacting
+     * with, which drops focus and makes the page jump. A row's own option
+     * set is invariant to its own value (it is "all types except those
+     * taken by OTHER rows"), so the select the user just changed is never
+     * rebuilt -- only the other rows are.
+     */
+    _rebuildEntityOptions: function (i) {
+      var sel = this['entityType' + i];
+      if (!sel) { return; }
+      var taken = this._entityTypesTaken(i);
+      var current = this._entityTypeOf(i);
+      var avail = this._ENTITY_TYPES.filter(function (t) {
+        return taken.indexOf(t.value) < 0;
+      });
+      if (!avail.length) { return; }
+      var keep = current && avail.some(function (t) { return t.value === current; })
+        ? current : avail[0].value;
+
+      var have = [];
+      for (var o = 0; o < sel.options.length; o++) { have.push(sel.options[o].value); }
+      var want = avail.map(function (t) { return t.value; });
+      var same = have.length === want.length && have.every(function (v, n) { return v === want[n]; });
+      if (same) {
+        if (sel.value !== keep) { sel.value = keep; }
+        return;
+      }
+
+      domConstruct.empty(sel);
+      avail.forEach(function (t) {
+        domConstruct.create('option', { value: t.value, innerHTML: t.label }, sel);
+      });
+      sel.value = keep;
+    },
+
+    /**
+     * Move each selector into the row that selected its type, hide the rest,
+     * and CLEAR any selector that is not currently shown.
+     *
+     * The clearing is load-bearing: getValues() reads every named widget via
+     * this.inherited(arguments) regardless of visibility, so a selector left
+     * populated after its row switched type would still be submitted -- the
+     * user would silently get an extra chain they did not ask for.
+     */
+    _refreshEntityRows: function () {
+      var self = this;
+      var shown = {};
+
+      // Moving selector nodes between rows reflows the form; if the page is
+      // scrolled, the browser loses its anchor and jumps. Pin the scroll
+      // position across the rearrangement and restore it afterwards.
+      var scroller = document.scrollingElement || document.documentElement;
+      var scrollTop = scroller ? scroller.scrollTop : 0;
+
+      for (var i = 0; i < 3; i++) {
+        var row = this['entityRow' + i];
+        if (!row) { continue; }
+        domStyle.set(row, 'display', i < this._entityRowCount ? '' : 'none');
+      }
+
+      for (var i = 0; i < this._entityRowCount; i++) {
+        this._rebuildEntityOptions(i);
+        var type = this._entityTypeOf(i);
+        var def = this._ENTITY_TYPES.filter(function (t) { return t.value === type; })[0];
+        if (!def) { continue; }
+        var widget = this[def.slot];
+        var slot = this['entitySlot' + i];
+        if (widget && slot && widget.domNode.parentNode !== slot) {
+          domConstruct.place(widget.domNode, slot);
+        }
+        shown[def.slot] = true;
+      }
+
+      this._ENTITY_TYPES.forEach(function (t) {
+        if (shown[t.slot]) { return; }
+        var w = self[t.slot];
+        if (!w) { return; }
+        if (w.get('value')) { w.set('value', ''); }   // see docblock
+        if (w.domNode.parentNode !== self.entityParking) {
+          domConstruct.place(w.domNode, self.entityParking);
+        }
+      });
+
+      // "+ Add" only on the last row, and only while a type is still free.
+      for (var i = 0; i < 3; i++) {
+        var btn = this['entityAdd' + i];
+        if (!btn) { continue; }
+        var last = (i === this._entityRowCount - 1);
+        domStyle.set(btn, 'display',
+          (last && this._entityRowCount < this._ENTITY_TYPES.length) ? '' : 'none');
+      }
+
+      if (scroller && scroller.scrollTop !== scrollTop) {
+        scroller.scrollTop = scrollTop;
+      }
+
+      this.checkParameterRequiredFields();
+    },
+
+    onEntityAdd: function () {
+      if (this._entityRowCount >= this._ENTITY_TYPES.length) { return; }
+      this._entityRowCount += 1;
+      this._refreshEntityRows();
+    },
+
+    onEntityRemove: function (evt) {
+      if (this._entityRowCount <= 1) { return; }
+      // Rows are removed from the end; the row's own selector is cleared by
+      // _refreshEntityRows once it is no longer shown.
+      this._entityRowCount -= 1;
+      this._refreshEntityRows();
+    },
+
+    onEntityTypeChange: function () {
+      this._refreshEntityRows();
     },
 
     // #51: no per-job progress is available (the prediction tools emit none),

--- a/public/js/p3/widget/app/templates/PredictStructure.html
+++ b/public/js/p3/widget/app/templates/PredictStructure.html
@@ -57,34 +57,69 @@
           </div>
         </div>
         <br>
-        <div class="appRow">
+        <!-- Typed entity rows. The three WorkspaceObjectSelectors keep their
+             original names (input_file / dna_file / rna_file) so the submission
+             payload and the app spec are unchanged -- this is presentation only.
+             Each row picks which one it shows; unused rows are hidden AND
+             cleared (a hidden-but-populated selector still serialises). -->
+        <div class="appRow" data-dojo-attach-point="entityRow0">
           <div class="appFieldLong">
-            <label>Protein</label><br>
-            <div data-dojo-type="p3/widget/WorkspaceObjectSelector" name="input_file" style="width:75%;"
-              data-dojo-attach-point="input_file"
-              data-dojo-attach-event="onChange:checkParameterRequiredFields"
-              data-dojo-props="type:['feature_protein_fasta','aligned_protein_fasta','contigs'],multi:false,promptMessage:'Protein sequence(s) in FASTA format (.fasta, .fa). Multi-chain complexes: include multiple sequences in one file. Maximum 26 sequences and 10,000 total residues per job. Boltz also accepts a YAML manifest for full feature support.',placeHolder:'Protein FASTA file'">
-            </div>
+            <select data-dojo-attach-point="entityType0"
+              data-dojo-attach-event="onChange:onEntityTypeChange"
+              style="width:22%;margin-right:6px;vertical-align:top;">
+              <option value="protein">Protein</option>
+              <option value="dna">DNA</option>
+              <option value="rna">RNA</option>
+            </select>
+            <span data-dojo-attach-point="entitySlot0" style="display:inline-block;width:70%;"></span>
+            <button type="button" data-dojo-attach-point="entityAdd0"
+              data-dojo-attach-event="onClick:onEntityAdd"
+              style="margin-left:6px;">+ Add</button>
           </div>
         </div>
-        <div class="appRow">
+        <div class="appRow" data-dojo-attach-point="entityRow1" style="display:none;">
           <div class="appFieldLong">
-            <label>DNA</label><br>
-            <div data-dojo-type="p3/widget/WorkspaceObjectSelector" name="dna_file" style="width:75%;"
-              data-dojo-attach-point="dna_file"
-              data-dojo-attach-event="onChange:checkParameterRequiredFields"
-              data-dojo-props="type:['feature_dna_fasta','aligned_dna_fasta','contigs'],multi:false,promptMessage:'DNA sequence(s) in FASTA format. Supported by Boltz-2, OpenFold 3, and Chai-1.',placeHolder:'DNA FASTA file'">
-            </div>
+            <select data-dojo-attach-point="entityType1"
+              data-dojo-attach-event="onChange:onEntityTypeChange"
+              style="width:22%;margin-right:6px;vertical-align:top;"></select>
+            <span data-dojo-attach-point="entitySlot1" style="display:inline-block;width:70%;"></span>
+            <button type="button" data-dojo-attach-point="entityAdd1"
+              data-dojo-attach-event="onClick:onEntityAdd"
+              style="margin-left:6px;">+ Add</button>
+            <button type="button" data-dojo-attach-point="entityRemove1"
+              data-dojo-attach-event="onClick:onEntityRemove"
+              title="Remove this input" style="margin-left:4px;">&times;</button>
           </div>
         </div>
-        <div class="appRow">
+        <div class="appRow" data-dojo-attach-point="entityRow2" style="display:none;">
           <div class="appFieldLong">
-            <label>RNA</label><br>
-            <div data-dojo-type="p3/widget/WorkspaceObjectSelector" name="rna_file" style="width:75%;"
-              data-dojo-attach-point="rna_file"
-              data-dojo-attach-event="onChange:checkParameterRequiredFields"
-              data-dojo-props="type:['feature_dna_fasta','aligned_dna_fasta','contigs'],multi:false,promptMessage:'RNA sequence(s) in FASTA format. Supported by Boltz-2, OpenFold 3, and Chai-1.',placeHolder:'RNA FASTA file'">
-            </div>
+            <select data-dojo-attach-point="entityType2"
+              data-dojo-attach-event="onChange:onEntityTypeChange"
+              style="width:22%;margin-right:6px;vertical-align:top;"></select>
+            <span data-dojo-attach-point="entitySlot2" style="display:inline-block;width:70%;"></span>
+            <button type="button" data-dojo-attach-point="entityRemove2"
+              data-dojo-attach-event="onClick:onEntityRemove"
+              title="Remove this input" style="margin-left:4px;">&times;</button>
+          </div>
+        </div>
+
+        <!-- The selectors themselves. Parked here and moved into whichever row
+             selects their type; names and props are exactly as before. -->
+        <div data-dojo-attach-point="entityParking" style="display:none;">
+          <div data-dojo-type="p3/widget/WorkspaceObjectSelector" name="input_file" style="width:100%;"
+            data-dojo-attach-point="input_file"
+            data-dojo-attach-event="onChange:checkParameterRequiredFields"
+            data-dojo-props="type:['feature_protein_fasta','aligned_protein_fasta','contigs'],multi:false,promptMessage:'Protein sequence(s) in FASTA format (.fasta, .fa). Multi-chain complexes: include multiple sequences in one file. Maximum 26 sequences and 10,000 total residues per job. Boltz also accepts a YAML manifest for full feature support.',placeHolder:'Protein FASTA file'">
+          </div>
+          <div data-dojo-type="p3/widget/WorkspaceObjectSelector" name="dna_file" style="width:100%;"
+            data-dojo-attach-point="dna_file"
+            data-dojo-attach-event="onChange:checkParameterRequiredFields"
+            data-dojo-props="type:['feature_dna_fasta','aligned_dna_fasta','contigs'],multi:false,promptMessage:'DNA sequence(s) in FASTA format. Both strands of a duplex go in one file as two records. Supported by Boltz-2, OpenFold 3, Chai-1 and ESMFold2.',placeHolder:'DNA FASTA file'">
+          </div>
+          <div data-dojo-type="p3/widget/WorkspaceObjectSelector" name="rna_file" style="width:100%;"
+            data-dojo-attach-point="rna_file"
+            data-dojo-attach-event="onChange:checkParameterRequiredFields"
+            data-dojo-props="type:['feature_dna_fasta','aligned_dna_fasta','contigs'],multi:false,promptMessage:'RNA sequence(s) in FASTA format. Supported by Boltz-2, OpenFold 3, Chai-1 and ESMFold2.',placeHolder:'RNA FASTA file'">
           </div>
         </div>
       </div>

--- a/public/js/p3/widget/app/tests/PredictStructure.entityRows.test.js
+++ b/public/js/p3/widget/app/tests/PredictStructure.entityRows.test.js
@@ -1,0 +1,156 @@
+/* eslint-env jest */
+//
+// Typed entity rows in the PredictStructure form.
+//
+// The rows are presentation only: the form must still submit exactly
+// input_file / dna_file / rna_file, leaving the app spec, service script and
+// CLI untouched. The risk is the clearing rule -- getValues() collects EVERY
+// named widget via this.inherited(arguments) regardless of visibility, so a
+// selector left populated after its row changed type would still be submitted
+// and the user would silently get a chain they never asked for.
+//
+// This loads the REAL methods out of PredictStructure.js rather than
+// reimplementing them, so it fails if that logic changes.
+//
+const fs = require('fs');
+const path = require('path');
+
+const SRC = path.resolve(__dirname, '..', 'PredictStructure.js');
+const src = fs.readFileSync(SRC, 'utf8');
+
+/** Extract a named method's parameter list and body from the source. */
+function grab(name) {
+  const i = src.indexOf('\n    ' + name + ': function');
+  if (i < 0) { throw new Error('method not found: ' + name); }
+  const sig = src.indexOf('function', i);
+  const paren = src.indexOf('(', sig);
+  const parenEnd = src.indexOf(')', paren);
+  const params = src.slice(paren, parenEnd + 1);
+  let j = src.indexOf('{', parenEnd), d = 0, k = j;
+  for (; k < src.length; k++) {
+    if (src[k] === '{') { d++; } else if (src[k] === '}') { d--; if (d === 0) { break; } }
+  }
+  return { params: params, body: src.slice(j, k + 1) };
+}
+
+const METHODS = ['_entityTypeOf', '_entityTypesTaken', '_rebuildEntityOptions',
+  '_refreshEntityRows', 'onEntityAdd', 'onEntityRemove'];
+
+const ENTITY_TYPES = [
+  { value: 'protein', label: 'Protein', slot: 'input_file' },
+  { value: 'dna', label: 'DNA', slot: 'dna_file' },
+  { value: 'rna', label: 'RNA', slot: 'rna_file' }
+];
+
+function mkSelect(vals, value) {
+  return { options: vals.map(function (v) { return { value: v }; }), value: value, tagName: 'SELECT' };
+}
+function mkWidget(name) {
+  return {
+    name: name, _v: '', domNode: { parentNode: null },
+    get: function () { return this._v; },
+    set: function (k, v) { if (k === 'value') { this._v = v; } }
+  };
+}
+
+function makeApp(rowTypes, files) {
+  global.document = { scrollingElement: { scrollTop: 0 }, documentElement: { scrollTop: 0 } };
+  global.domStyle = { set: function () {} };
+  global.domConstruct = {
+    empty: function (sel) { sel.options = []; },
+    create: function (tag, props, parent) { const o = { value: props.value }; parent.options.push(o); return o; },
+    place: function (node, parent) { node.parentNode = parent; }
+  };
+
+  const app = {
+    _ENTITY_TYPES: ENTITY_TYPES,
+    _entityRowCount: rowTypes.length,
+    entityParking: { parking: true },
+    checkParameterRequiredFields: function () {}
+  };
+  for (let i = 0; i < 3; i++) {
+    app['entityRow' + i] = {};
+    app['entityAdd' + i] = {};
+    app['entityRemove' + i] = {};
+    app['entitySlot' + i] = { slot: i };
+    app['entityType' + i] = mkSelect(['protein', 'dna', 'rna'], rowTypes[i] || null);
+  }
+  ENTITY_TYPES.forEach(function (t) { app[t.slot] = mkWidget(t.slot); });
+  Object.keys(files).forEach(function (slot) { app[slot]._v = files[slot]; });
+  METHODS.forEach(function (m) {
+    const g = grab(m);
+    /* eslint-disable no-eval */
+    app[m] = eval('(function' + g.params + g.body + ')');
+    /* eslint-enable no-eval */
+  });
+  return app;
+}
+
+/** Mirror of getValues()'s _copyIfPresent over the three file parameters. */
+function submissionOf(app) {
+  const out = {};
+  ENTITY_TYPES.forEach(function (t) {
+    const v = app[t.slot].get('value');
+    if (v) { out[t.slot] = v; }
+  });
+  return out;
+}
+
+function submissionFor(rowTypes, files) {
+  const app = makeApp(rowTypes, files);
+  app._refreshEntityRows();
+  return submissionOf(app);
+}
+
+describe('PredictStructure typed entity rows', () => {
+  test('all three rows submit all three files', () => {
+    expect(submissionFor(['protein', 'dna', 'rna'],
+      { input_file: 'p.fasta', dna_file: 'd.fasta', rna_file: 'r.fasta' }))
+      .toEqual({ input_file: 'p.fasta', dna_file: 'd.fasta', rna_file: 'r.fasta' });
+  });
+
+  test('two rows submit only those two files', () => {
+    expect(submissionFor(['protein', 'dna'], { input_file: 'p.fasta', dna_file: 'd.fasta' }))
+      .toEqual({ input_file: 'p.fasta', dna_file: 'd.fasta' });
+  });
+
+  test('a single protein row submits only the protein file', () => {
+    expect(submissionFor(['protein'], { input_file: 'p.fasta' }))
+      .toEqual({ input_file: 'p.fasta' });
+  });
+
+  test('protein is not required: a DNA-only job submits only dna_file', () => {
+    expect(submissionFor(['dna'], { dna_file: 'd.fasta' }))
+      .toEqual({ dna_file: 'd.fasta' });
+  });
+
+  test('switching a row type clears the file chosen under the old type', () => {
+    expect(submissionFor(['rna'], { dna_file: 'stale.fasta', rna_file: 'r.fasta' }))
+      .toEqual({ rna_file: 'r.fasta' });
+  });
+
+  test('removing a row drops its file from the submission', () => {
+    expect(submissionFor(['protein'], { input_file: 'p.fasta', rna_file: 'orphan.fasta' }))
+      .toEqual({ input_file: 'p.fasta' });
+  });
+
+  test("a row's own option set never changes with its own value", () => {
+    // Why the active <select> is never rebuilt: rebuilding the element the
+    // user just clicked drops focus and makes the page jump.
+    const avail = (rows, i) => ENTITY_TYPES
+      .map((t) => t.value)
+      .filter((v) => !rows.filter((_, j) => j !== i).includes(v));
+    const perms = (a) => (a.length <= 1 ? [a] : a.flatMap((v, i) =>
+      perms(a.slice(0, i).concat(a.slice(i + 1))).map((p) => [v].concat(p))));
+    let transitions = 0;
+    [1, 2, 3].forEach((n) => perms(ENTITY_TYPES.map((t) => t.value)).forEach((p) => {
+      const rows = p.slice(0, n);
+      rows.forEach((_, i) => avail(rows, i).forEach((nv) => {
+        transitions++;
+        const after = rows.slice(); after[i] = nv;
+        expect(avail(after, i)).toEqual(avail(rows, i));
+      }));
+    }));
+    expect(transitions).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
The three biomolecular inputs are fixed slots labelled Protein / DNA / RNA. That presentation gives no hint that they are independent chains of a single complex, that any subset is valid, or that protein is not required at all — several of the tools predict nucleic-acid-only structures.

Replaced with rows that each carry a type dropdown and a file selector:

- row 1 offers all three types, plus **+ Add**
- row 2 offers only the two remaining types, plus **+ Add**
- row 3 takes the single remaining type; no **+ Add** appears
- rows 2 and 3 carry a remove button, freeing that type again

**Presentation only — no backend change.** The three `WorkspaceObjectSelector` widgets keep their names, so the submission is still `input_file` / `dna_file` / `rna_file`. The app spec, service script and CLI are untouched, existing saved jobs are unaffected, and no service container rebuild is involved.

## Two subtleties, both handled and commented in the code

**Hidden selectors are cleared.** `getValues()` collects every named widget via `this.inherited(arguments)` regardless of visibility, so switching a row's type after choosing a file would otherwise submit both, and the user would silently get a chain they never asked for.

**A `<select>` is rebuilt only when its option set actually changed.** Emptying the element the user just clicked drops focus and makes the page jump. A row's options are *all types except those taken by other rows*, which is invariant to its own value, so the active row is never rebuilt. Scroll position is pinned across the DOM moves as well.

## Tests

New `public/js/p3/widget/app/tests/PredictStructure.entityRows.test.js` — 7 assertions run by `npm test`. `jest.config.json` roots extended to include `public/js/p3/widget/app`; the existing copilot suite still passes (13/13 total).

The test loads the **real methods** out of `PredictStructure.js` rather than reimplementing them, so it fails if that logic drifts. It covers all three rows submitting all three files, two rows, one row, a DNA-only job, the stale-file clearing, row removal, and the invariance property above across every reachable transition. Mutation-tested: removing the clearing rule turns 2 tests red.

## Background

The tools that accept nucleic acids (Boltz-2, OpenFold 3, Chai-1, ESMFold2) are AlphaFold-3 class and predict protein + DNA + RNA in one complex — the CRISPR-Cas9 shape, for instance. Nucleic-acid-only input is a supported category rather than an accident: AF3 benchmarks "low homology RNA-only or DNA-only complexes", and Boltz's parser accepts `{protein, dna, rna, ligand}` with no protein requirement. Verified end to end against the deployed service.